### PR TITLE
[FLINK-27094][Buildsystem] Enable issue link tracking to PRs based on…

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -19,6 +19,7 @@
 labelPRBasedOnFilePath:
   component=BuildSystem:
     - .github/**/*
+    - tools/maven/*
 
   component=Documentation:
     - docs/**/*
@@ -27,13 +28,32 @@ labelPRBasedOnFilePath:
     - flink-connector-elasticsearch*/**/*
     - flink-sql-connector-elasticsearch*/**/*
 
+###### IssueLink Adder #################################################################################################
+# Insert Issue (Jira/Github etc) link in PR description based on the Issue ID in PR title.
+insertIssueLinkInPrDescription:
+  # specify the placeholder for the issue link that should be present in the description
+  descriptionIssuePlaceholderRegexp: "^Issue link: (.*)$"
+  matchers:
+    # you can have several matches - for different types of issues
+    # only the first matching entry is replaced
+    jiraIssueMatch:
+      # specify the regexp of issue id that you can find in the title of the PR
+      # the match groups can be used to build the issue id (${1}, ${2}, etc.).
+      titleIssueIdRegexp: \[(FLINK-[0-9]+)\]
+      # the issue link to be added. ${1}, ${2} ... are replaced with the match groups from the
+      # title match (remember to use quotes)
+      descriptionIssueLink: "[${1}](https://issues.apache.org/jira/browse/${1}/)"
+    docOnlyIssueMatch:
+      titleIssueIdRegexp: \[hotfix\]
+      descriptionIssueLink: "`Documentation only change, no JIRA issue`"
+
 ###### Title Validator #################################################################################################
 # Verifies if commit/PR titles match the regexp specified
 verifyTitles:
   # Regular expression that should be matched by titles of commits or PR
   titleRegexp: ^\[FLINK-[0-9]+\].*$|^\[FLINK-XXXXX\].*$|^\hotfix.*$
   # If set to true, it will always check the PR title (as opposed to the individual commits).
-  alwaysUsePrTitle: true
+  alwaysUsePrTitle: false
   # If set to true, it will only check the commit in case there is a single commit.
   # In case of multiple commits it will check PR title.
   # This reflects the standard behaviour of Github that for `Squash & Merge` GitHub
@@ -56,7 +76,7 @@ labelerFlags:
   # and not when existing PR is updated.
   # The default is 'true' which means the labels would be added when PR is updated even if they
   # were removed by the user
-  labelOnPRUpdates: false
+  labelOnPRUpdates: true
 
 # Comment to be posted to welcome users when they open their first PR
 firstPRWelcomeComment: >


### PR DESCRIPTION
… the ticket ID from the PR title. This also changes the default validator from PR only to commit messages.