### PR TITLE
[hotfix] Changing comment structure for go.mod due to incorrect comment indicator

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,21 +1,19 @@
-/*
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-*/
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 module github.com/apache/flink-connector-elasticsearch/docs
 


### PR DESCRIPTION
Running `hugo mod get -u github.com/apache/flink-connector-elasticsearch/docs` results in:

```
go: no module dependencies to download
go: github.com/apache/flink-connector-elasticsearch/docs@v0.0.0-20220425163347-3adb2b36dbc6: parsing go.mod: go.mod:1: mod files must use // comments (not /* */ comments)
go: no module dependencies to download
```