### PR TITLE
[hotfix] Fix typo

### DIFF
--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
@@ -197,7 +197,7 @@ public abstract class ElasticsearchSinkBuilderBase<
     }
 
     /**
-     * Sets the password used to authenticate the conection with the Elasticsearch cluster.
+     * Sets the password used to authenticate the connection with the Elasticsearch cluster.
      *
      * @param password of the Elasticsearch cluster user
      * @return this builder


### PR DESCRIPTION
The comment of ElasticsearchSinkBuilderBase has a typo.