### PR TITLE
[FLINK-27757][Connector][Elasticsearch] Elasticsearch connector should not use `flink-table-planner` but `flink-table-planner-loader`

### DIFF
--- a/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connector-elasticsearch6/pom.xml
@@ -146,7 +146,14 @@ under the License.
 		<!-- Table API integration tests -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<artifactId>flink-table-planner-loader</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
 			<version>${flink.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connector-elasticsearch7/pom.xml
+++ b/flink-connector-elasticsearch7/pom.xml
@@ -143,7 +143,14 @@ under the License.
 		<!-- Table API integration tests -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<artifactId>flink-table-planner-loader</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
 			<version>${flink.version}</version>
 			<scope>test</scope>
 		</dependency>


### PR DESCRIPTION
We also need to add `flink-table-runtime` to avoid ClassNotFoundException on `org.apache.flink.table.shaded.com.jayway.jsonpath.spi.mapper.MappingProvider`