### PR TITLE
[FLINK-28109][connector/elasticsearch] Delete useful code in the row emitter

### DIFF
--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/RowElasticsearchEmitter.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/RowElasticsearchEmitter.java
@@ -92,7 +92,6 @@ class RowElasticsearchEmitter implements ElasticsearchEmitter<RowData> {
         } else {
             final IndexRequest indexRequest =
                     new IndexRequest(indexGenerator.generate(row), documentType)
-                            .id(key)
                             .source(document, contentType);
             indexer.add(indexRequest);
         }


### PR DESCRIPTION
Delete id(key) in the RowElasticsearchEmitter class

the key is always null, this makes users get confused.