### PR TITLE
[FLINK-28904][python][docs] Add missing connector/format doc

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/elasticsearch.md
+++ b/docs/content.zh/docs/connectors/datastream/elasticsearch.md
@@ -51,6 +51,8 @@ under the License.
   </tbody>
 </table>
 
+{{< py_download_link "elastic" >}}
+
 请注意，流连接器目前不是二进制发行版的一部分。
 有关如何将程序和用于集群执行的库一起打包，参考[此文档]({{< ref "docs/dev/configuration/overview" >}})。
 

--- a/docs/content/docs/connectors/datastream/elasticsearch.md
+++ b/docs/content/docs/connectors/datastream/elasticsearch.md
@@ -53,6 +53,8 @@ of the Elasticsearch installation:
   </tbody>
 </table>
 
+{{< py_download_link "elastic" >}}
+
 Note that the streaming connectors are currently not part of the binary
 distribution. See [here]({{< ref "docs/dev/configuration/overview" >}}) for information
 about how to package the program with the libraries for cluster execution.


### PR DESCRIPTION
This PR fixes missing JAR download link for PyFlink users.