### PR TITLE
[FLINK-28911] Ensure the SerializationSchema has been opened.

### DIFF
--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/RowElasticsearchEmitter.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/RowElasticsearchEmitter.java
@@ -60,8 +60,9 @@ class RowElasticsearchEmitter implements ElasticsearchEmitter<RowData> {
     }
 
     @Override
-    public void open() {
+    public void open() throws Exception {
         indexGenerator.open();
+        serializationSchema.open(null);
     }
 
     @Override

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/RowElasticsearchSinkFunction.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/RowElasticsearchSinkFunction.java
@@ -67,8 +67,9 @@ class RowElasticsearchSinkFunction implements ElasticsearchSinkFunction<RowData>
     }
 
     @Override
-    public void open() {
+    public void open() throws Exception {
         indexGenerator.open();
+        serializationSchema.open(null);
     }
 
     @Override


### PR DESCRIPTION
Proposed fix for https://issues.apache.org/jira/browse/FLINK-28911

I'm a bit in doubt if it is good enough to simply pass a null value to the open method.
It works in this case; but are there cases where a reaal value is needed?
