### PR TITLE
[hotfix] Move away from deprecated RestHighLevelClient#bulkAsync

### DIFF
--- a/flink-connector-elasticsearch6/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch6SinkBuilder.java
+++ b/flink-connector-elasticsearch6/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch6SinkBuilder.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -83,7 +84,10 @@ public class Elasticsearch6SinkBuilder<IN>
                                             BulkRequest bulkRequest,
                                             ActionListener<BulkResponse>
                                                     bulkResponseActionListener) {
-                                        client.bulkAsync(bulkRequest, bulkResponseActionListener);
+                                        client.bulkAsync(
+                                                bulkRequest,
+                                                RequestOptions.DEFAULT,
+                                                bulkResponseActionListener);
                                     }
                                 },
                                 listener);


### PR DESCRIPTION
## What is the purpose of the change

The PR makes use `RestHighLevelClient#bulkAsync` with RequestOptions instead of deprecated one as it recommended in javadoc [1] and as it is already done for elastic7 [2]
[1] https://github.com/elastic/elasticsearch/blob/6.8/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java#L498-L507
[2] https://github.com/apache/flink/blob/master/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch7SinkBuilder.java#L85-L88

