### PR TITLE
[FLINK-29310][ci] Check licensing 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,11 @@ jobs:
         jdk: [8, 11]
     timeout-minutes: 30
     env:
+      MVN_COMMON_OPTIONS: -U -B --no-transfer-progress
       MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       FLINK_URL: https://s3.amazonaws.com/flink-nightly/flink-1.16-SNAPSHOT-bin-scala_2.12.tgz
+      MVN_BUILD_OUTPUT_FILE: "/tmp/mvn_build_output.out"
+      MVN_VALIDATION_DIR: "/tmp/flink-validation-deployment"
     steps:
       - run: echo "Running CI pipeline for JDK version ${{ matrix.jdk }}"
 
@@ -53,9 +56,20 @@ jobs:
       - name: Compile and test flink-connector-elasticsearch
         timeout-minutes: 20
         run: |          
-          mvn clean install -U -B --no-transfer-progress \
+          set -o pipefail
+
+          mvn clean deploy ${MVN_COMMON_OPTIONS} \
+            -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
             -Dscala-2.12 \
             -Prun-end-to-end-tests -DdistDir=$(pwd)/../flink-1.16-SNAPSHOT \
             -Dflink.convergence.phase=install -Pcheck-convergence \
+            ${{ env.MVN_CONNECTION_OPTIONS }} \
+            -Dlog4j.configurationFile=file://$(pwd)/tools/ci/log4j.properties \
+            | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
+
+      - name: Check licensing
+        run: |
+          mvn ${MVN_COMMON_OPTIONS} exec:java@check-licensing -N \
+            -Dexec.args="${{ env.MVN_BUILD_OUTPUT_FILE }} $(pwd) ${{ env.MVN_VALIDATION_DIR }}" \
             ${{ env.MVN_CONNECTION_OPTIONS }} \
             -Dlog4j.configurationFile=file://$(pwd)/tools/ci/log4j.properties

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,15 @@ under the License.
 		</developerConnection>
 	</scm>
 
+	<pluginRepositories>
+		<pluginRepository>
+			<!-- Allows exec-maven-plugin to resolve snapshot plugin dependencies -->
+			<id>apache.snapshots.https</id>
+			<name>${distMgmtSnapshotsName}</name>
+			<url>${distMgmtSnapshotsUrl}</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<modules>
 		<module>flink-connector-elasticsearch-base</module>
 		<module>flink-connector-elasticsearch6</module>
@@ -751,6 +760,35 @@ under the License.
 				<version>3.0.1</version>
 				<inherited>true</inherited>
 				<extensions>true</extensions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>3.1.0</version>
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>check-license</id>
+						<!-- manually called -->
+						<phase>none</phase>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<mainClass>org.apache.flink.tools.ci.licensecheck.LicenseChecker</mainClass>
+					<includePluginDependencies>true</includePluginDependencies>
+					<includeProjectDependencies>false</includeProjectDependencies>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.flink</groupId>
+						<artifactId>flink-ci-tools</artifactId>
+						<version>1.16-SNAPSHOT</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 
 			<plugin>

--- a/tools/ci/log4j.properties
+++ b/tools/ci/log4j.properties
@@ -17,7 +17,7 @@
 ################################################################################
 
 rootLogger.level = INFO
-rootLogger.appenderRef.out.ref = FileAppender
+rootLogger.appenderRef.out.ref = ConsoleAppender
 
 # -----------------------------------------------------------------------------
 # Console (use 'console')


### PR DESCRIPTION
Runs the NoticeFileChecker on CI.

Additionally changes CI logging to output to the console, since otherwise we don't see any license checker output.