### PR TITLE
[FLINK-29042][Connectors/ElasticSearch] Support lookup join for es connector

### DIFF
--- a/flink-connector-elasticsearch-base/pom.xml
+++ b/flink-connector-elasticsearch-base/pom.xml
@@ -164,6 +164,14 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
+			<version>${flink.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
 		<!-- ArchUit test dependencies -->
 
 		<dependency>

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
@@ -19,9 +19,11 @@
 package org.apache.flink.streaming.connectors.elasticsearch;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.tuple.Tuple2;
 
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.search.SearchRequest;
 
 import javax.annotation.Nullable;
 
@@ -60,6 +62,21 @@ public interface ElasticsearchApiCallBridge<C extends AutoCloseable> extends Ser
      * @return the bulk processor builder.
      */
     BulkProcessor.Builder createBulkProcessorBuilder(C client, BulkProcessor.Listener listener);
+
+    /**
+     * Executes a search using the Search API.
+     *
+     * @param client the Elasticsearch client.
+     * @param searchRequest A request to execute search against one or more indices (or all).
+     */
+    Tuple2<String, String[]> search(C client, SearchRequest searchRequest) throws IOException;
+
+    /**
+     * Closes this client and releases any system resources associated with it.
+     *
+     * @param client the Elasticsearch client.
+     */
+    void close(C client) throws IOException;
 
     /**
      * Extracts the cause of failure of a bulk item action.

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchRowDataLookupFunction.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchRowDataLookupFunction.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchApiCallBridge;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.LookupFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.Preconditions;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** A lookup function implementing {@link LookupTableSource} in elasticsearch connector. */
+@Internal
+public class ElasticsearchRowDataLookupFunction<C extends AutoCloseable> extends LookupFunction {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(ElasticsearchRowDataLookupFunction.class);
+    private static final long serialVersionUID = 1L;
+
+    private final DeserializationSchema<RowData> deserializationSchema;
+
+    private final String index;
+    private final String type;
+
+    private final String[] producedNames;
+    private final String[] lookupKeys;
+    private final int maxRetryTimes;
+    // converters to convert data from internal to external in order to generate keys for the cache.
+    private final DataFormatConverters.DataFormatConverter[] converters;
+    private SearchRequest searchRequest;
+    private SearchSourceBuilder searchSourceBuilder;
+
+    private final ElasticsearchApiCallBridge<C> callBridge;
+
+    private transient C client;
+
+    public ElasticsearchRowDataLookupFunction(
+            DeserializationSchema<RowData> deserializationSchema,
+            int maxRetryTimes,
+            String index,
+            String type,
+            String[] producedNames,
+            DataType[] producedTypes,
+            String[] lookupKeys,
+            ElasticsearchApiCallBridge<C> callBridge) {
+
+        checkNotNull(deserializationSchema, "No DeserializationSchema supplied.");
+        checkNotNull(maxRetryTimes, "No maxRetryTimes supplied.");
+        checkNotNull(producedNames, "No fieldNames supplied.");
+        checkNotNull(producedTypes, "No fieldTypes supplied.");
+        checkNotNull(lookupKeys, "No keyNames supplied.");
+        checkNotNull(callBridge, "No ElasticsearchApiCallBridge supplied.");
+
+        this.deserializationSchema = deserializationSchema;
+        this.maxRetryTimes = maxRetryTimes;
+        this.index = index;
+        this.type = type;
+        this.producedNames = producedNames;
+        this.lookupKeys = lookupKeys;
+        this.converters = new DataFormatConverters.DataFormatConverter[lookupKeys.length];
+        Map<String, Integer> nameToIndex =
+                IntStream.range(0, producedNames.length)
+                        .boxed()
+                        .collect(Collectors.toMap(i -> producedNames[i], i -> i));
+        for (int i = 0; i < lookupKeys.length; i++) {
+            Integer position = nameToIndex.get(lookupKeys[i]);
+            Preconditions.checkArgument(
+                    position != null, "Lookup keys %s not selected", Arrays.toString(lookupKeys));
+            converters[i] = DataFormatConverters.getConverterForDataType(producedTypes[position]);
+        }
+
+        this.callBridge = callBridge;
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        this.client = callBridge.createClient(null);
+
+        // Set searchRequest in open method in case of amount of calling in eval method when every
+        // record comes.
+        this.searchRequest = new SearchRequest(index);
+        if (type == null) {
+            searchRequest.types(Strings.EMPTY_ARRAY);
+        } else {
+            searchRequest.types(type);
+        }
+        searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.fetchSource(producedNames, null);
+        deserializationSchema.open(null);
+    }
+
+    @Override
+    public Collection<RowData> lookup(RowData keyRow) {
+        BoolQueryBuilder lookupCondition = new BoolQueryBuilder();
+        for (int i = 0; i < lookupKeys.length; i++) {
+            lookupCondition.must(
+                    new TermQueryBuilder(lookupKeys[i], converters[i].toExternal(keyRow, i)));
+        }
+        searchSourceBuilder.query(lookupCondition);
+        searchRequest.source(searchSourceBuilder);
+
+        for (int retry = 0; retry <= maxRetryTimes; retry++) {
+            try {
+                ArrayList<RowData> rows = new ArrayList<>();
+                Tuple2<String, String[]> searchResponse = callBridge.search(client, searchRequest);
+                if (searchResponse.f1.length > 0) {
+                    String[] result = searchResponse.f1;
+                    for (String s : result) {
+                        RowData row = parseSearchResult(s);
+                        rows.add(row);
+                    }
+                    rows.trimToSize();
+                    return rows;
+                }
+            } catch (IOException e) {
+                LOG.error(String.format("Elasticsearch search error, retry times = %d", retry), e);
+                if (retry >= maxRetryTimes) {
+                    throw new RuntimeException("Execution of Elasticsearch search failed.", e);
+                }
+                try {
+                    Thread.sleep(1000L * retry);
+                } catch (InterruptedException e1) {
+                    LOG.warn(
+                            "Interrupted while waiting to retry failed elasticsearch search, aborting");
+                    throw new RuntimeException(e1);
+                }
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    private RowData parseSearchResult(String result) {
+        RowData row = null;
+        try {
+            row = deserializationSchema.deserialize(result.getBytes());
+        } catch (IOException e) {
+            LOG.error("Deserialize search hit failed: " + e.getMessage());
+        }
+
+        return row;
+    }
+}

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchRowDataLookupFunction.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchRowDataLookupFunction.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.data.util.DataFormatConverters;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.LookupFunction;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
 import org.elasticsearch.action.search.SearchRequest;
@@ -49,7 +50,7 @@ import java.util.stream.IntStream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
-/** A lookup function implementing {@link LookupTableSource} in elasticsearch connector. */
+/** A lookup function implementing {@link LookupTableSource} in Elasticsearch connector. */
 @Internal
 public class ElasticsearchRowDataLookupFunction<C extends AutoCloseable> extends LookupFunction {
 
@@ -155,14 +156,14 @@ public class ElasticsearchRowDataLookupFunction<C extends AutoCloseable> extends
             } catch (IOException e) {
                 LOG.error(String.format("Elasticsearch search error, retry times = %d", retry), e);
                 if (retry >= maxRetryTimes) {
-                    throw new RuntimeException("Execution of Elasticsearch search failed.", e);
+                    throw new FlinkRuntimeException("Execution of Elasticsearch search failed.", e);
                 }
                 try {
                     Thread.sleep(1000L * retry);
                 } catch (InterruptedException e1) {
                     LOG.warn(
                             "Interrupted while waiting to retry failed elasticsearch search, aborting");
-                    throw new RuntimeException(e1);
+                    throw new FlinkRuntimeException(e1);
                 }
             }
         }

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchRowDataLookupFunction.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchRowDataLookupFunction.java
@@ -115,7 +115,7 @@ public class ElasticsearchRowDataLookupFunction<C extends AutoCloseable> extends
 
     @Override
     public void open(FunctionContext context) throws Exception {
-        this.client = callBridge.createClient(null);
+        this.client = callBridge.createClient();
 
         // Set searchRequest in open method in case of amount of calling in eval method when every
         // record comes.

--- a/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
+++ b/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.elasticsearch;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.core.testutils.MultiShotLatch;
@@ -35,6 +36,7 @@ import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.junit.Test;
@@ -43,6 +45,7 @@ import org.mockito.stubbing.Answer;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -602,6 +605,15 @@ public class ElasticsearchSinkBaseTest {
                 Client client, BulkProcessor.Listener listener) {
             return null;
         }
+
+        @Override
+        public Tuple2<String, String[]> search(Client client, SearchRequest searchRequest)
+                throws IOException {
+            return null;
+        }
+
+        @Override
+        public void close(Client client) throws IOException {}
 
         @Nullable
         @Override

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/pom.xml
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/pom.xml
@@ -78,6 +78,11 @@ under the License.
 			<artifactId>junit-jupiter</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge</artifactId>
+			<version>${flink.version}</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/src/main/java/org/apache/flink/streaming/tests/ElasticsearchLookupE2ECase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/src/main/java/org/apache/flink/streaming/tests/ElasticsearchLookupE2ECase.java
@@ -41,10 +41,11 @@ import java.util.stream.Collectors;
 import static org.apache.flink.table.api.Expressions.$;
 import static org.junit.Assert.assertEquals;
 
+/** Base class for end to end Elasticsearch lookup. */
 public abstract class ElasticsearchLookupE2ECase {
     protected EnvironmentSettings streamSettings;
-    protected static final String dim = "testTable1";
-    protected static final String es_index = "es1";
+    protected static final String DIM = "testTable1";
+    protected static final String ES_INDEX = "es1";
     // prepare a source collection.
     private static final List<Row> srcData = new ArrayList<>();
     private static final RowTypeInfo testTypeInfo =
@@ -79,7 +80,7 @@ public abstract class ElasticsearchLookupE2ECase {
 
         tEnv.executeSql(
                 "CREATE TABLE "
-                        + dim
+                        + DIM
                         + " ("
                         + " id int,"
                         + " name string,"
@@ -87,9 +88,9 @@ public abstract class ElasticsearchLookupE2ECase {
                         + ") WITH ("
                         + getEsOptions()
                         + ")");
-        tEnv.executeSql("insert into " + dim + " values (1, 'rick')");
-        tEnv.executeSql("insert into " + dim + " values (2, 'john')");
-        tEnv.executeSql("insert into " + dim + " values (3, 'ted')");
+        tEnv.executeSql("insert into " + DIM + " values (1, 'rick')");
+        tEnv.executeSql("insert into " + DIM + " values (2, 'john')");
+        tEnv.executeSql("insert into " + DIM + " values (3, 'ted')");
 
         // prepare a source table
         String srcTableName = "src";
@@ -106,7 +107,7 @@ public abstract class ElasticsearchLookupE2ECase {
                         + " id,"
                         + " name"
                         + " FROM src JOIN "
-                        + dim
+                        + DIM
                         + " FOR SYSTEM_TIME AS OF src.proc as h ON src.a = h.id";
         Iterator<Row> collected = tEnv.executeSql(dimJoinQuery).collect();
         List<String> result =

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/src/main/java/org/apache/flink/streaming/tests/ElasticsearchLookupE2ECase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/src/main/java/org/apache/flink/streaming/tests/ElasticsearchLookupE2ECase.java
@@ -1,0 +1,107 @@
+package org.apache.flink.streaming.tests;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.junit.Assert.assertEquals;
+
+public abstract class ElasticsearchLookupE2ECase {
+    protected EnvironmentSettings streamSettings;
+    protected static final String dim = "testTable1";
+    protected static final String es_index = "es1";
+    // prepare a source collection.
+    private static final List<Row> srcData = new ArrayList<>();
+    private static final RowTypeInfo testTypeInfo =
+            new RowTypeInfo(
+                    new TypeInformation[] {Types.INT, Types.LONG, Types.STRING},
+                    new String[] {"a", "b", "c"});
+
+    ElasticsearchContainer elasticsearchContainer = null;
+
+    static {
+        srcData.add(Row.of(1, 1L, "Hi"));
+        srcData.add(Row.of(2, 2L, "Hello"));
+        srcData.add(Row.of(3, 2L, "Hello Yubin Li"));
+        srcData.add(Row.of(4, 999L, "Hello Yubin Li !"));
+    }
+
+    abstract String getElasticsearchContainerName();
+
+    abstract String getEsOptions();
+
+    @Before
+    public void before() {
+        this.streamSettings = EnvironmentSettings.inStreamingMode();
+        elasticsearchContainer = new ElasticsearchContainer(getElasticsearchContainerName());
+        elasticsearchContainer.start();
+    }
+
+    @Test
+    public void testEsLookupTableSource() {
+        StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
+
+        tEnv.executeSql(
+                "CREATE TABLE "
+                        + dim
+                        + " ("
+                        + " id int,"
+                        + " name string,"
+                        + " PRIMARY KEY (id) NOT ENFORCED"
+                        + ") WITH ("
+                        + getEsOptions()
+                        + ")");
+        tEnv.executeSql("insert into " + dim + " values (1, 'rick')");
+        tEnv.executeSql("insert into " + dim + " values (2, 'john')");
+        tEnv.executeSql("insert into " + dim + " values (3, 'ted')");
+
+        // prepare a source table
+        String srcTableName = "src";
+        DataStream<Row> srcDs = execEnv.fromCollection(srcData).returns(testTypeInfo);
+        Table in = tEnv.fromDataStream(srcDs, $("a"), $("b"), $("c"), $("proc").proctime());
+        tEnv.registerTable(srcTableName, in);
+
+        // perform a temporal table join query
+        String dimJoinQuery =
+                "SELECT"
+                        + " a,"
+                        + " b,"
+                        + " c,"
+                        + " id,"
+                        + " name"
+                        + " FROM src JOIN "
+                        + dim
+                        + " FOR SYSTEM_TIME AS OF src.proc as h ON src.a = h.id";
+        Iterator<Row> collected = tEnv.executeSql(dimJoinQuery).collect();
+        List<String> result =
+                CollectionUtil.iteratorToList(collected).stream()
+                        .map(Row::toString)
+                        .sorted()
+                        .collect(Collectors.toList());
+
+        List<String> expected = new ArrayList<>();
+        expected.add("+I[1, 1, Hi, 1, rick]");
+        expected.add("+I[2, 2, Hello, 2, john]");
+        expected.add("+I[3, 2, Hello Yubin Li, 3, ted]");
+
+        assertEquals(expected, result);
+    }
+}

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/src/main/java/org/apache/flink/streaming/tests/ElasticsearchLookupE2ECase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/src/main/java/org/apache/flink/streaming/tests/ElasticsearchLookupE2ECase.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.flink.streaming.tests;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch6-e2e-tests/pom.xml
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch6-e2e-tests/pom.xml
@@ -74,6 +74,24 @@ under the License.
 			<version>${log4j.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-loader</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-json</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch6-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch6LookupE2ECase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch6-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch6LookupE2ECase.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.tests;
 
 import org.apache.flink.util.DockerImageVersions;
 
+/** End-to-end test for Elasticsearch6 lookup. */
 public class Elasticsearch6LookupE2ECase extends ElasticsearchLookupE2ECase {
     @Override
     String getElasticsearchContainerName() {
@@ -35,7 +36,7 @@ public class Elasticsearch6LookupE2ECase extends ElasticsearchLookupE2ECase {
                 + "',"
                 + "'document-type' = '_doc',"
                 + "'index' = '"
-                + es_index
+                + ES_INDEX
                 + "',"
                 + "'lookup.cache' = 'partial',"
                 + "'lookup.partial-cache.max-rows' = '100'";

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch6-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch6LookupE2ECase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch6-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch6LookupE2ECase.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.tests;
 
-import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.connector.elasticsearch.test.DockerImageVersions;
 
 /** End-to-end test for Elasticsearch6 lookup. */
 public class Elasticsearch6LookupE2ECase extends ElasticsearchLookupE2ECase {

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch6-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch6LookupE2ECase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch6-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch6LookupE2ECase.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.flink.streaming.tests;
 
 import org.apache.flink.util.DockerImageVersions;

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch6-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch6LookupE2ECase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch6-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch6LookupE2ECase.java
@@ -1,0 +1,25 @@
+package org.apache.flink.streaming.tests;
+
+import org.apache.flink.util.DockerImageVersions;
+
+public class Elasticsearch6LookupE2ECase extends ElasticsearchLookupE2ECase {
+    @Override
+    String getElasticsearchContainerName() {
+        return DockerImageVersions.ELASTICSEARCH_6;
+    }
+
+    @Override
+    String getEsOptions() {
+        return " 'connector' = 'elasticsearch-6',"
+                + " 'hosts' = '"
+                + "http://"
+                + elasticsearchContainer.getHttpHostAddress()
+                + "',"
+                + "'document-type' = '_doc',"
+                + "'index' = '"
+                + es_index
+                + "',"
+                + "'lookup.cache' = 'partial',"
+                + "'lookup.partial-cache.max-rows' = '100'";
+    }
+}

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch7-e2e-tests/pom.xml
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch7-e2e-tests/pom.xml
@@ -74,6 +74,24 @@ under the License.
 			<version>${log4j.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-loader</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-json</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch7-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch7LookupE2ECase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch7-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch7LookupE2ECase.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.tests;
 
-import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.connector.elasticsearch.test.DockerImageVersions;
 
 /** End-to-end test for Elasticsearch7 lookup. */
 public class Elasticsearch7LookupE2ECase extends ElasticsearchLookupE2ECase {

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch7-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch7LookupE2ECase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch7-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch7LookupE2ECase.java
@@ -1,0 +1,24 @@
+package org.apache.flink.streaming.tests;
+
+import org.apache.flink.util.DockerImageVersions;
+
+public class Elasticsearch7LookupE2ECase extends ElasticsearchLookupE2ECase {
+    @Override
+    String getElasticsearchContainerName() {
+        return DockerImageVersions.ELASTICSEARCH_7;
+    }
+
+    @Override
+    String getEsOptions() {
+        return " 'connector' = 'elasticsearch-7',"
+                + " 'hosts' = '"
+                + "http://"
+                + elasticsearchContainer.getHttpHostAddress()
+                + "',"
+                + "'index' = '"
+                + es_index
+                + "',"
+                + "'lookup.cache' = 'partial',"
+                + "'lookup.partial-cache.max-rows' = '100'";
+    }
+}

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch7-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch7LookupE2ECase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch7-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch7LookupE2ECase.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.flink.streaming.tests;
 
 import org.apache.flink.util.DockerImageVersions;

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch7-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch7LookupE2ECase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch7-e2e-tests/src/test/java/org/apache/flink/streaming/tests/Elasticsearch7LookupE2ECase.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.tests;
 
 import org.apache.flink.util.DockerImageVersions;
 
+/** End-to-end test for Elasticsearch7 lookup. */
 public class Elasticsearch7LookupE2ECase extends ElasticsearchLookupE2ECase {
     @Override
     String getElasticsearchContainerName() {
@@ -34,7 +35,7 @@ public class Elasticsearch7LookupE2ECase extends ElasticsearchLookupE2ECase {
                 + elasticsearchContainer.getHttpHostAddress()
                 + "',"
                 + "'index' = '"
-                + es_index
+                + ES_INDEX
                 + "',"
                 + "'lookup.cache' = 'partial',"
                 + "'lookup.partial-cache.max-rows' = '100'";

--- a/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSource.java
+++ b/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSource.java
@@ -120,7 +120,7 @@ public class Elasticsearch6DynamicSource implements LookupTableSource, SupportsP
 
     @Override
     public String asSummaryString() {
-        return "Elasticsearch-6";
+        return "Elasticsearch6";
     }
 
     @Override

--- a/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSource.java
+++ b/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSource.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.streaming.connectors.elasticsearch6.Elasticsearch6ApiCallBridge;
+import org.apache.flink.streaming.connectors.elasticsearch6.RestClientFactory;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.connector.source.lookup.LookupFunctionProvider;
+import org.apache.flink.table.connector.source.lookup.PartialCachingLookupProvider;
+import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
+
+import org.elasticsearch.client.RestHighLevelClient;
+
+import javax.annotation.Nullable;
+
+/**
+ * A {@link DynamicTableSource} that describes how to create a {@link Elasticsearch6DynamicSource}
+ * from a logical description.
+ */
+@Internal
+public class Elasticsearch6DynamicSource implements LookupTableSource, SupportsProjectionPushDown {
+
+    private final DecodingFormat<DeserializationSchema<RowData>> format;
+    private final Elasticsearch6Configuration config;
+    private final int lookupMaxRetryTimes;
+    private final LookupCache lookupCache;
+    private DataType physicalRowDataType;
+
+    public Elasticsearch6DynamicSource(
+            DecodingFormat<DeserializationSchema<RowData>> format,
+            Elasticsearch6Configuration config,
+            DataType physicalRowDataType,
+            int lookupMaxRetryTimes,
+            @Nullable LookupCache lookupCache) {
+        this.format = format;
+        this.config = config;
+        this.physicalRowDataType = physicalRowDataType;
+        this.lookupMaxRetryTimes = lookupMaxRetryTimes;
+        this.lookupCache = lookupCache;
+    }
+
+    @Override
+    public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context) {
+        RestClientFactory restClientFactory = null;
+        if (config.getUsername().isPresent()
+                && config.getPassword().isPresent()
+                && !StringUtils.isNullOrWhitespaceOnly(config.getUsername().get())
+                && !StringUtils.isNullOrWhitespaceOnly(config.getPassword().get())) {
+            restClientFactory =
+                    new Elasticsearch6DynamicSink.AuthRestClientFactory(
+                            config.getPathPrefix().orElse(null),
+                            config.getUsername().get(),
+                            config.getPassword().get());
+        } else {
+            restClientFactory =
+                    new Elasticsearch6DynamicSink.DefaultRestClientFactory(
+                            config.getPathPrefix().orElse(null));
+        }
+
+        Elasticsearch6ApiCallBridge elasticsearch6ApiCallBridge =
+                new Elasticsearch6ApiCallBridge(config.getHosts(), restClientFactory);
+
+        // Elasticsearch only support non-nested look up keys
+        String[] keyNames = new String[context.getKeys().length];
+        for (int i = 0; i < keyNames.length; i++) {
+            int[] innerKeyArr = context.getKeys()[i];
+            Preconditions.checkArgument(
+                    innerKeyArr.length == 1, "Elasticsearch only support non-nested look up keys");
+            keyNames[i] = DataType.getFieldNames(physicalRowDataType).get(innerKeyArr[0]);
+        }
+
+        ElasticsearchRowDataLookupFunction<RestHighLevelClient> lookupFunction =
+                new ElasticsearchRowDataLookupFunction<>(
+                        this.format.createRuntimeDecoder(context, physicalRowDataType),
+                        lookupMaxRetryTimes,
+                        config.getIndex(),
+                        config.getDocumentType(),
+                        DataType.getFieldNames(physicalRowDataType).toArray(new String[0]),
+                        DataType.getFieldDataTypes(physicalRowDataType).toArray(new DataType[0]),
+                        keyNames,
+                        elasticsearch6ApiCallBridge);
+        if (lookupCache != null) {
+            return PartialCachingLookupProvider.of(lookupFunction, lookupCache);
+        } else {
+            return LookupFunctionProvider.of(lookupFunction);
+        }
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        return new Elasticsearch6DynamicSource(
+                format, config, physicalRowDataType, lookupMaxRetryTimes, lookupCache);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "Elasticsearch-6";
+    }
+
+    @Override
+    public boolean supportsNestedProjection() {
+        return false;
+    }
+
+    @Override
+    public void applyProjection(int[][] projectedFields, DataType type) {
+        this.physicalRowDataType = Projection.of(projectedFields).project(type);
+    }
+}

--- a/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicTableFactory.java
+++ b/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicTableFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.connectors.elasticsearch.table;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
@@ -26,14 +27,25 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.lookup.LookupOptions;
+import org.apache.flink.table.connector.source.lookup.cache.DefaultLookupCache;
+import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.SerializationFormatFactory;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.flink.util.StringUtils;
+
+import javax.annotation.Nullable;
 
 import java.time.ZoneId;
 import java.util.Set;
@@ -48,6 +60,7 @@ import static org.apache.flink.streaming.connectors.elasticsearch.table.Elastics
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.BULK_FLUSH_INTERVAL_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.BULK_FLUSH_MAX_ACTIONS_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.CONNECTION_PATH_PREFIX;
+import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.DOCUMENT_TYPE_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.FAILURE_HANDLER_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.FLUSH_ON_CHECKPOINT_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.FORMAT_OPTION;
@@ -56,12 +69,22 @@ import static org.apache.flink.streaming.connectors.elasticsearch.table.Elastics
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.KEY_DELIMITER_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.PASSWORD_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.USERNAME_OPTION;
+import static org.apache.flink.table.connector.source.lookup.LookupOptions.CACHE_TYPE;
+import static org.apache.flink.table.connector.source.lookup.LookupOptions.MAX_RETRIES;
+import static org.apache.flink.table.connector.source.lookup.LookupOptions.PARTIAL_CACHE_CACHE_MISSING_KEY;
+import static org.apache.flink.table.connector.source.lookup.LookupOptions.PARTIAL_CACHE_EXPIRE_AFTER_ACCESS;
+import static org.apache.flink.table.connector.source.lookup.LookupOptions.PARTIAL_CACHE_EXPIRE_AFTER_WRITE;
+import static org.apache.flink.table.connector.source.lookup.LookupOptions.PARTIAL_CACHE_MAX_ROWS;
 
-/** A {@link DynamicTableSinkFactory} for discovering {@link Elasticsearch7DynamicSink}. */
+/**
+ * A {@link DynamicTableFactory} for discovering {@link Elasticsearch6DynamicSource} and {@link
+ * Elasticsearch6DynamicSink}.
+ */
 @Internal
-public class Elasticsearch7DynamicSinkFactory implements DynamicTableSinkFactory {
+public class Elasticsearch6DynamicTableFactory
+        implements DynamicTableSourceFactory, DynamicTableSinkFactory {
     private static final Set<ConfigOption<?>> requiredOptions =
-            Stream.of(HOSTS_OPTION, INDEX_OPTION).collect(Collectors.toSet());
+            Stream.of(HOSTS_OPTION, INDEX_OPTION, DOCUMENT_TYPE_OPTION).collect(Collectors.toSet());
     private static final Set<ConfigOption<?>> optionalOptions =
             Stream.of(
                             KEY_DELIMITER_OPTION,
@@ -76,14 +99,46 @@ public class Elasticsearch7DynamicSinkFactory implements DynamicTableSinkFactory
                             CONNECTION_PATH_PREFIX,
                             FORMAT_OPTION,
                             PASSWORD_OPTION,
-                            USERNAME_OPTION)
+                            USERNAME_OPTION,
+                            CACHE_TYPE,
+                            PARTIAL_CACHE_EXPIRE_AFTER_ACCESS,
+                            PARTIAL_CACHE_EXPIRE_AFTER_WRITE,
+                            PARTIAL_CACHE_MAX_ROWS,
+                            PARTIAL_CACHE_CACHE_MISSING_KEY,
+                            MAX_RETRIES)
                     .collect(Collectors.toSet());
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        DataType physicalRowDataType = context.getPhysicalRowDataType();
+        final FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(this, context);
+        final ReadableConfig options = helper.getOptions();
+        final DecodingFormat<DeserializationSchema<RowData>> format =
+                helper.discoverDecodingFormat(
+                        DeserializationFormatFactory.class,
+                        org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions
+                                .FORMAT_OPTION);
+
+        helper.validate();
+
+        Configuration configuration = new Configuration();
+        context.getCatalogTable().getOptions().forEach(configuration::setString);
+        Elasticsearch6Configuration config =
+                new Elasticsearch6Configuration(configuration, context.getClassLoader());
+
+        return new Elasticsearch6DynamicSource(
+                format,
+                config,
+                physicalRowDataType,
+                options.get(MAX_RETRIES),
+                getLookupCache(options));
+    }
 
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
         TableSchema tableSchema = context.getCatalogTable().getSchema();
         ElasticsearchValidationUtils.validatePrimaryKey(tableSchema);
-
         final FactoryUtil.TableFactoryHelper helper =
                 FactoryUtil.createTableFactoryHelper(this, context);
 
@@ -93,16 +148,27 @@ public class Elasticsearch7DynamicSinkFactory implements DynamicTableSinkFactory
         helper.validate();
         Configuration configuration = new Configuration();
         context.getCatalogTable().getOptions().forEach(configuration::setString);
-        Elasticsearch7Configuration config =
-                new Elasticsearch7Configuration(configuration, context.getClassLoader());
+        Elasticsearch6Configuration config =
+                new Elasticsearch6Configuration(configuration, context.getClassLoader());
 
         validate(config, configuration);
 
-        return new Elasticsearch7DynamicSink(
+        return new Elasticsearch6DynamicSink(
                 format,
                 config,
                 TableSchemaUtils.getPhysicalSchema(tableSchema),
                 getLocalTimeZoneId(context.getConfiguration()));
+    }
+
+    @Nullable
+    private LookupCache getLookupCache(ReadableConfig tableOptions) {
+        LookupCache cache = null;
+        if (tableOptions
+                .get(LookupOptions.CACHE_TYPE)
+                .equals(LookupOptions.LookupCacheType.PARTIAL)) {
+            cache = DefaultLookupCache.fromConfig(tableOptions);
+        }
+        return cache;
     }
 
     ZoneId getLocalTimeZoneId(ReadableConfig readableConfig) {
@@ -115,7 +181,7 @@ public class Elasticsearch7DynamicSinkFactory implements DynamicTableSinkFactory
         return zoneId;
     }
 
-    private void validate(Elasticsearch7Configuration config, Configuration originalConfiguration) {
+    private void validate(Elasticsearch6Configuration config, Configuration originalConfiguration) {
         config.getFailureHandler(); // checks if we can instantiate the custom failure handler
         config.getHosts(); // validate hosts
         validate(
@@ -169,7 +235,7 @@ public class Elasticsearch7DynamicSinkFactory implements DynamicTableSinkFactory
 
     @Override
     public String factoryIdentifier() {
-        return "elasticsearch-7";
+        return "elasticsearch-6";
     }
 
     @Override

--- a/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6ApiCallBridge.java
+++ b/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6ApiCallBridge.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.elasticsearch6;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchApiCallBridge;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
@@ -27,10 +28,13 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.SearchHit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +43,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 
 /** Implementation of {@link ElasticsearchApiCallBridge} for Elasticsearch 6 and later versions. */
 @Internal
@@ -55,7 +60,8 @@ public class Elasticsearch6ApiCallBridge
     /** The factory to configure the rest client. */
     private final RestClientFactory restClientFactory;
 
-    Elasticsearch6ApiCallBridge(List<HttpHost> httpHosts, RestClientFactory restClientFactory) {
+    public Elasticsearch6ApiCallBridge(
+            List<HttpHost> httpHosts, RestClientFactory restClientFactory) {
         Preconditions.checkArgument(httpHosts != null && !httpHosts.isEmpty());
         this.httpHosts = httpHosts;
         this.restClientFactory = Preconditions.checkNotNull(restClientFactory);
@@ -76,6 +82,21 @@ public class Elasticsearch6ApiCallBridge
     public BulkProcessor.Builder createBulkProcessorBuilder(
             RestHighLevelClient client, BulkProcessor.Listener listener) {
         return BulkProcessor.builder(client::bulkAsync, listener);
+    }
+
+    @Override
+    public Tuple2<String, String[]> search(RestHighLevelClient client, SearchRequest searchRequest)
+            throws IOException {
+        SearchResponse searchResponse = client.search(searchRequest);
+        SearchHit[] searchHits = searchResponse.getHits().getHits();
+        return new Tuple2<>(
+                searchResponse.getScrollId(),
+                Stream.of(searchHits).map(SearchHit::getSourceAsString).toArray(String[]::new));
+    }
+
+    @Override
+    public void close(RestHighLevelClient client) throws IOException {
+        client.close();
     }
 
     @Override

--- a/flink-connector-elasticsearch6/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connector-elasticsearch6/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.streaming.connectors.elasticsearch.table.Elasticsearch6DynamicSinkFactory
+org.apache.flink.streaming.connectors.elasticsearch.table.Elasticsearch6DynamicTableFactory

--- a/flink-connector-elasticsearch6/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch6DynamicTableFactoryTest.java
+++ b/flink-connector-elasticsearch6/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch6DynamicTableFactoryTest.java
@@ -25,17 +25,18 @@ import org.junit.jupiter.api.Test;
 import static org.apache.flink.connector.elasticsearch.table.TestContext.context;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Tests for validation in {@link Elasticsearch7DynamicSinkFactory}. */
-public class Elasticsearch7DynamicSinkFactoryTest extends ElasticsearchDynamicSinkFactoryBaseTest {
+/** Tests for validation in {@link Elasticsearch6DynamicSinkFactory}. */
+public class Elasticsearch6DynamicTableFactoryTest extends ElasticsearchDynamicSinkFactoryBaseTest {
     @Override
     ElasticsearchDynamicSinkFactoryBase createSinkFactory() {
-        return new Elasticsearch7DynamicSinkFactory();
+        return new Elasticsearch6DynamicSinkFactory();
     }
 
     @Override
     TestContext createPrefilledTestContext() {
         return context()
                 .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
+                .withOption(Elasticsearch6ConnectorOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                 .withOption(
                         ElasticsearchConnectorOptions.HOSTS_OPTION.key(), "http://localhost:12345");
     }
@@ -51,6 +52,7 @@ public class Elasticsearch7DynamicSinkFactoryTest extends ElasticsearchDynamicSi
                                 + "\n"
                                 + "Missing required options are:\n"
                                 + "\n"
+                                + "document-type\n"
                                 + "hosts\n"
                                 + "index");
     }

--- a/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
+++ b/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
@@ -114,12 +114,11 @@ public class Elasticsearch6DynamicSinkITCase extends TestLogger {
 
         String index = "writing-documents";
         String myType = "MyType";
-        Elasticsearch6DynamicSinkFactory sinkFactory = new Elasticsearch6DynamicSinkFactory();
+        Elasticsearch6DynamicTableFactory factory = new Elasticsearch6DynamicTableFactory();
 
         SinkFunctionProvider sinkRuntimeProvider =
                 (SinkFunctionProvider)
-                        sinkFactory
-                                .createDynamicTableSink(
+                        factory.createDynamicTableSink(
                                         context()
                                                 .withSchema(schema)
                                                 .withOption(

--- a/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicTableFactoryTest.java
+++ b/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicTableFactoryTest.java
@@ -35,13 +35,13 @@ import java.util.Collections;
 
 import static org.apache.flink.streaming.connectors.elasticsearch.table.TestContext.context;
 
-/** Tests for validation in {@link Elasticsearch7DynamicSinkFactory}. */
-public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
+/** Tests for validation in {@link Elasticsearch6DynamicTableFactory}. */
+public class Elasticsearch6DynamicTableFactoryTest extends TestLogger {
     @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void validateEmptyConfiguration() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch6DynamicTableFactory factory = new Elasticsearch6DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
@@ -49,45 +49,53 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
                         + "\n"
                         + "Missing required options are:\n"
                         + "\n"
+                        + "document-type\n"
                         + "hosts\n"
                         + "index");
-        sinkFactory.createDynamicTableSink(context().build());
+        factory.createDynamicTableSink(context().build());
     }
 
     @Test
     public void validateWrongIndex() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch6DynamicTableFactory factory = new Elasticsearch6DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage("'index' must not be empty");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withOption("index", "")
+                        .withOption("document-type", "MyType")
                         .withOption("hosts", "http://localhost:12345")
                         .build());
     }
 
     @Test
     public void validateWrongHosts() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch6DynamicTableFactory factory = new Elasticsearch6DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
                 "Could not parse host 'wrong-host' in option 'hosts'. It should follow the format 'http://host_name:port'.");
-        sinkFactory.createDynamicTableSink(
-                context().withOption("index", "MyIndex").withOption("hosts", "wrong-host").build());
+        factory.createDynamicTableSink(
+                context()
+                        .withOption("index", "MyIndex")
+                        .withOption("document-type", "MyType")
+                        .withOption("hosts", "wrong-host")
+                        .build());
     }
 
     @Test
     public void validateWrongFlushSize() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch6DynamicTableFactory factory = new Elasticsearch6DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
                 "'sink.bulk-flush.max-size' must be in MB granularity. Got: 1024 bytes");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
+                        .withOption(
+                                ElasticsearchConnectorOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(
                                 ElasticsearchConnectorOptions.HOSTS_OPTION.key(),
                                 "http://localhost:1234")
@@ -99,13 +107,15 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongRetries() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch6DynamicTableFactory factory = new Elasticsearch6DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage("'sink.bulk-flush.backoff.max-retries' must be at least 1. Got: 0");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
+                        .withOption(
+                                ElasticsearchConnectorOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(
                                 ElasticsearchConnectorOptions.HOSTS_OPTION.key(),
                                 "http://localhost:1234")
@@ -118,13 +128,15 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongMaxActions() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch6DynamicTableFactory factory = new Elasticsearch6DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage("'sink.bulk-flush.max-actions' must be at least 1. Got: -2");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
+                        .withOption(
+                                ElasticsearchConnectorOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(
                                 ElasticsearchConnectorOptions.HOSTS_OPTION.key(),
                                 "http://localhost:1234")
@@ -136,13 +148,15 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongBackoffDelay() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch6DynamicTableFactory factory = new Elasticsearch6DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage("Invalid value for option 'sink.bulk-flush.backoff.delay'.");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
+                        .withOption(
+                                ElasticsearchConnectorOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(
                                 ElasticsearchConnectorOptions.HOSTS_OPTION.key(),
                                 "http://localhost:1234")
@@ -154,7 +168,7 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validatePrimaryKeyOnIllegalColumn() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch6DynamicTableFactory factory = new Elasticsearch6DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
@@ -162,7 +176,7 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
                         + "[ARRAY, MAP, MULTISET, ROW, RAW, VARBINARY].\n"
                         + " Elasticsearch sink does not support primary keys on columns of types: "
                         + "[ARRAY, MAP, MULTISET, STRUCTURED_TYPE, ROW, RAW, BINARY, VARBINARY].");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withSchema(
                                 new ResolvedSchema(
@@ -216,17 +230,19 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongCredential() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch6DynamicTableFactory factory = new Elasticsearch6DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
                 "'username' and 'password' must be set at the same time. Got: username 'username' and password ''");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
                         .withOption(
                                 ElasticsearchConnectorOptions.HOSTS_OPTION.key(),
                                 "http://localhost:1234")
+                        .withOption(
+                                ElasticsearchConnectorOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(ElasticsearchConnectorOptions.USERNAME_OPTION.key(), "username")
                         .withOption(ElasticsearchConnectorOptions.PASSWORD_OPTION.key(), "")
                         .build());

--- a/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSource.java
+++ b/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSource.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.streaming.connectors.elasticsearch7.Elasticsearch7ApiCallBridge;
+import org.apache.flink.streaming.connectors.elasticsearch7.RestClientFactory;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.connector.source.lookup.LookupFunctionProvider;
+import org.apache.flink.table.connector.source.lookup.PartialCachingLookupProvider;
+import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
+
+import org.elasticsearch.client.RestHighLevelClient;
+
+import javax.annotation.Nullable;
+
+/**
+ * A {@link DynamicTableSource} that describes how to create a {@link Elasticsearch7DynamicSource}
+ * from a logical description.
+ */
+@Internal
+public class Elasticsearch7DynamicSource implements LookupTableSource, SupportsProjectionPushDown {
+
+    private final DecodingFormat<DeserializationSchema<RowData>> format;
+    private final Elasticsearch7Configuration config;
+    private final int lookupMaxRetryTimes;
+    private final LookupCache lookupCache;
+    private DataType physicalRowDataType;
+
+    public Elasticsearch7DynamicSource(
+            DecodingFormat<DeserializationSchema<RowData>> format,
+            Elasticsearch7Configuration config,
+            DataType physicalRowDataType,
+            int lookupMaxRetryTimes,
+            @Nullable LookupCache lookupCache) {
+        this.format = format;
+        this.config = config;
+        this.physicalRowDataType = physicalRowDataType;
+        this.lookupMaxRetryTimes = lookupMaxRetryTimes;
+        this.lookupCache = lookupCache;
+    }
+
+    @Override
+    public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context) {
+        RestClientFactory restClientFactory = null;
+        if (config.getUsername().isPresent()
+                && config.getPassword().isPresent()
+                && !StringUtils.isNullOrWhitespaceOnly(config.getUsername().get())
+                && !StringUtils.isNullOrWhitespaceOnly(config.getPassword().get())) {
+            restClientFactory =
+                    new Elasticsearch7DynamicSink.AuthRestClientFactory(
+                            config.getPathPrefix().orElse(null),
+                            config.getUsername().get(),
+                            config.getPassword().get());
+        } else {
+            restClientFactory =
+                    new Elasticsearch7DynamicSink.DefaultRestClientFactory(
+                            config.getPathPrefix().orElse(null));
+        }
+
+        Elasticsearch7ApiCallBridge elasticsearch6ApiCallBridge =
+                new Elasticsearch7ApiCallBridge(config.getHosts(), restClientFactory);
+
+        // Elasticsearch only support non-nested look up keys
+        String[] keyNames = new String[context.getKeys().length];
+        for (int i = 0; i < keyNames.length; i++) {
+            int[] innerKeyArr = context.getKeys()[i];
+            Preconditions.checkArgument(
+                    innerKeyArr.length == 1, "Elasticsearch only support non-nested look up keys");
+            keyNames[i] = DataType.getFieldNames(physicalRowDataType).get(innerKeyArr[0]);
+        }
+
+        ElasticsearchRowDataLookupFunction<RestHighLevelClient> lookupFunction =
+                new ElasticsearchRowDataLookupFunction<>(
+                        this.format.createRuntimeDecoder(context, physicalRowDataType),
+                        lookupMaxRetryTimes,
+                        config.getIndex(),
+                        config.getDocumentType(),
+                        DataType.getFieldNames(physicalRowDataType).toArray(new String[0]),
+                        DataType.getFieldDataTypes(physicalRowDataType).toArray(new DataType[0]),
+                        keyNames,
+                        elasticsearch6ApiCallBridge);
+        if (lookupCache != null) {
+            return PartialCachingLookupProvider.of(lookupFunction, lookupCache);
+        } else {
+            return LookupFunctionProvider.of(lookupFunction);
+        }
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        return new Elasticsearch7DynamicSource(
+                format, config, physicalRowDataType, lookupMaxRetryTimes, lookupCache);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "Elasticsearch-6";
+    }
+
+    @Override
+    public boolean supportsNestedProjection() {
+        return false;
+    }
+
+    @Override
+    public void applyProjection(int[][] projectedFields, DataType type) {
+        this.physicalRowDataType = Projection.of(projectedFields).project(type);
+    }
+}

--- a/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSource.java
+++ b/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSource.java
@@ -83,7 +83,7 @@ public class Elasticsearch7DynamicSource implements LookupTableSource, SupportsP
                             config.getPathPrefix().orElse(null));
         }
 
-        Elasticsearch7ApiCallBridge elasticsearch6ApiCallBridge =
+        Elasticsearch7ApiCallBridge elasticsearch7ApiCallBridge =
                 new Elasticsearch7ApiCallBridge(config.getHosts(), restClientFactory);
 
         // Elasticsearch only support non-nested look up keys
@@ -104,7 +104,7 @@ public class Elasticsearch7DynamicSource implements LookupTableSource, SupportsP
                         DataType.getFieldNames(physicalRowDataType).toArray(new String[0]),
                         DataType.getFieldDataTypes(physicalRowDataType).toArray(new DataType[0]),
                         keyNames,
-                        elasticsearch6ApiCallBridge);
+                        elasticsearch7ApiCallBridge);
         if (lookupCache != null) {
             return PartialCachingLookupProvider.of(lookupFunction, lookupCache);
         } else {
@@ -120,7 +120,7 @@ public class Elasticsearch7DynamicSource implements LookupTableSource, SupportsP
 
     @Override
     public String asSummaryString() {
-        return "Elasticsearch-6";
+        return "Elasticsearch7";
     }
 
     @Override

--- a/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7ApiCallBridge.java
+++ b/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7ApiCallBridge.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.elasticsearch7;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchApiCallBridge;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
@@ -27,11 +28,14 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.SearchHit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +44,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 
 /** Implementation of {@link ElasticsearchApiCallBridge} for Elasticsearch 7 and later versions. */
 @Internal
@@ -56,7 +61,8 @@ public class Elasticsearch7ApiCallBridge
     /** The factory to configure the rest client. */
     private final RestClientFactory restClientFactory;
 
-    Elasticsearch7ApiCallBridge(List<HttpHost> httpHosts, RestClientFactory restClientFactory) {
+    public Elasticsearch7ApiCallBridge(
+            List<HttpHost> httpHosts, RestClientFactory restClientFactory) {
         Preconditions.checkArgument(httpHosts != null && !httpHosts.isEmpty());
         this.httpHosts = httpHosts;
         this.restClientFactory = Preconditions.checkNotNull(restClientFactory);
@@ -80,6 +86,21 @@ public class Elasticsearch7ApiCallBridge
                 (request, bulkListener) ->
                         client.bulkAsync(request, RequestOptions.DEFAULT, bulkListener),
                 listener);
+    }
+
+    @Override
+    public Tuple2<String, String[]> search(RestHighLevelClient client, SearchRequest searchRequest)
+            throws IOException {
+        SearchResponse searchResponse = client.search(searchRequest, RequestOptions.DEFAULT);
+        SearchHit[] searchHits = searchResponse.getHits().getHits();
+        return new Tuple2<>(
+                searchResponse.getScrollId(),
+                Stream.of(searchHits).map(SearchHit::getSourceAsString).toArray(String[]::new));
+    }
+
+    @Override
+    public void close(RestHighLevelClient client) throws IOException {
+        client.close();
     }
 
     @Override

--- a/flink-connector-elasticsearch7/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connector-elasticsearch7/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.streaming.connectors.elasticsearch.table.Elasticsearch7DynamicSinkFactory
+org.apache.flink.streaming.connectors.elasticsearch.table.Elasticsearch7DynamicTableFactory

--- a/flink-connector-elasticsearch7/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch7DynamicTableFactoryTest.java
+++ b/flink-connector-elasticsearch7/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch7DynamicTableFactoryTest.java
@@ -25,18 +25,17 @@ import org.junit.jupiter.api.Test;
 import static org.apache.flink.connector.elasticsearch.table.TestContext.context;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Tests for validation in {@link Elasticsearch6DynamicSinkFactory}. */
-public class Elasticsearch6DynamicSinkFactoryTest extends ElasticsearchDynamicSinkFactoryBaseTest {
+/** Tests for validation in {@link Elasticsearch7DynamicSinkFactory}. */
+public class Elasticsearch7DynamicTableFactoryTest extends ElasticsearchDynamicSinkFactoryBaseTest {
     @Override
     ElasticsearchDynamicSinkFactoryBase createSinkFactory() {
-        return new Elasticsearch6DynamicSinkFactory();
+        return new Elasticsearch7DynamicSinkFactory();
     }
 
     @Override
     TestContext createPrefilledTestContext() {
         return context()
                 .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
-                .withOption(Elasticsearch6ConnectorOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                 .withOption(
                         ElasticsearchConnectorOptions.HOSTS_OPTION.key(), "http://localhost:12345");
     }
@@ -52,7 +51,6 @@ public class Elasticsearch6DynamicSinkFactoryTest extends ElasticsearchDynamicSi
                                 + "\n"
                                 + "Missing required options are:\n"
                                 + "\n"
-                                + "document-type\n"
                                 + "hosts\n"
                                 + "index");
     }

--- a/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
+++ b/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
@@ -107,12 +107,11 @@ public class Elasticsearch7DynamicSinkITCase extends TestLogger {
                                 LocalDateTime.parse("2012-12-12T12:12:12")));
 
         String index = "writing-documents";
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory factory = new Elasticsearch7DynamicTableFactory();
 
         SinkFunctionProvider sinkRuntimeProvider =
                 (SinkFunctionProvider)
-                        sinkFactory
-                                .createDynamicTableSink(
+                        factory.createDynamicTableSink(
                                         context()
                                                 .withSchema(schema)
                                                 .withOption(

--- a/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicTableFactoryTest.java
+++ b/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicTableFactoryTest.java
@@ -35,13 +35,13 @@ import java.util.Collections;
 
 import static org.apache.flink.streaming.connectors.elasticsearch.table.TestContext.context;
 
-/** Tests for validation in {@link Elasticsearch6DynamicSinkFactory}. */
-public class Elasticsearch6DynamicSinkFactoryTest extends TestLogger {
+/** Tests for validation in {@link Elasticsearch7DynamicTableFactory}. */
+public class Elasticsearch7DynamicTableFactoryTest extends TestLogger {
     @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void validateEmptyConfiguration() {
-        Elasticsearch6DynamicSinkFactory sinkFactory = new Elasticsearch6DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory factory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
@@ -49,53 +49,45 @@ public class Elasticsearch6DynamicSinkFactoryTest extends TestLogger {
                         + "\n"
                         + "Missing required options are:\n"
                         + "\n"
-                        + "document-type\n"
                         + "hosts\n"
                         + "index");
-        sinkFactory.createDynamicTableSink(context().build());
+        factory.createDynamicTableSink(context().build());
     }
 
     @Test
     public void validateWrongIndex() {
-        Elasticsearch6DynamicSinkFactory sinkFactory = new Elasticsearch6DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory factory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage("'index' must not be empty");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withOption("index", "")
-                        .withOption("document-type", "MyType")
                         .withOption("hosts", "http://localhost:12345")
                         .build());
     }
 
     @Test
     public void validateWrongHosts() {
-        Elasticsearch6DynamicSinkFactory sinkFactory = new Elasticsearch6DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory factory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
                 "Could not parse host 'wrong-host' in option 'hosts'. It should follow the format 'http://host_name:port'.");
-        sinkFactory.createDynamicTableSink(
-                context()
-                        .withOption("index", "MyIndex")
-                        .withOption("document-type", "MyType")
-                        .withOption("hosts", "wrong-host")
-                        .build());
+        factory.createDynamicTableSink(
+                context().withOption("index", "MyIndex").withOption("hosts", "wrong-host").build());
     }
 
     @Test
     public void validateWrongFlushSize() {
-        Elasticsearch6DynamicSinkFactory sinkFactory = new Elasticsearch6DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory factory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
                 "'sink.bulk-flush.max-size' must be in MB granularity. Got: 1024 bytes");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
-                        .withOption(
-                                ElasticsearchConnectorOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(
                                 ElasticsearchConnectorOptions.HOSTS_OPTION.key(),
                                 "http://localhost:1234")
@@ -107,15 +99,13 @@ public class Elasticsearch6DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongRetries() {
-        Elasticsearch6DynamicSinkFactory sinkFactory = new Elasticsearch6DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory factory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage("'sink.bulk-flush.backoff.max-retries' must be at least 1. Got: 0");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
-                        .withOption(
-                                ElasticsearchConnectorOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(
                                 ElasticsearchConnectorOptions.HOSTS_OPTION.key(),
                                 "http://localhost:1234")
@@ -128,15 +118,13 @@ public class Elasticsearch6DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongMaxActions() {
-        Elasticsearch6DynamicSinkFactory sinkFactory = new Elasticsearch6DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory factory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage("'sink.bulk-flush.max-actions' must be at least 1. Got: -2");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
-                        .withOption(
-                                ElasticsearchConnectorOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(
                                 ElasticsearchConnectorOptions.HOSTS_OPTION.key(),
                                 "http://localhost:1234")
@@ -148,15 +136,13 @@ public class Elasticsearch6DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongBackoffDelay() {
-        Elasticsearch6DynamicSinkFactory sinkFactory = new Elasticsearch6DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory factory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage("Invalid value for option 'sink.bulk-flush.backoff.delay'.");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
-                        .withOption(
-                                ElasticsearchConnectorOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(
                                 ElasticsearchConnectorOptions.HOSTS_OPTION.key(),
                                 "http://localhost:1234")
@@ -168,7 +154,7 @@ public class Elasticsearch6DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validatePrimaryKeyOnIllegalColumn() {
-        Elasticsearch6DynamicSinkFactory sinkFactory = new Elasticsearch6DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory factory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
@@ -176,7 +162,7 @@ public class Elasticsearch6DynamicSinkFactoryTest extends TestLogger {
                         + "[ARRAY, MAP, MULTISET, ROW, RAW, VARBINARY].\n"
                         + " Elasticsearch sink does not support primary keys on columns of types: "
                         + "[ARRAY, MAP, MULTISET, STRUCTURED_TYPE, ROW, RAW, BINARY, VARBINARY].");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withSchema(
                                 new ResolvedSchema(
@@ -230,19 +216,17 @@ public class Elasticsearch6DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongCredential() {
-        Elasticsearch6DynamicSinkFactory sinkFactory = new Elasticsearch6DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory factory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
                 "'username' and 'password' must be set at the same time. Got: username 'username' and password ''");
-        sinkFactory.createDynamicTableSink(
+        factory.createDynamicTableSink(
                 context()
                         .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
                         .withOption(
                                 ElasticsearchConnectorOptions.HOSTS_OPTION.key(),
                                 "http://localhost:1234")
-                        .withOption(
-                                ElasticsearchConnectorOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(ElasticsearchConnectorOptions.USERNAME_OPTION.key(), "username")
                         .withOption(ElasticsearchConnectorOptions.PASSWORD_OPTION.key(), "")
                         .build());


### PR DESCRIPTION
Now es connector could only be used as a sink, but in many business scenarios, we treat es as a index database, thus we should support to make it lookupable in flink.