### PR TITLE
[FLINK-29468][FLINK-29638] Upgrade jackson bom to 2.13.4.20221013

### DIFF
--- a/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -6,12 +6,12 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
 - org.apache.httpcomponents:httpasyncclient:4.1.2

--- a/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -7,10 +7,10 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.carrotsearch:hppc:0.8.1
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4
 - com.github.spullara.mustache.java:compiler:0.9.6
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@ under the License.
 		<flink.version>1.16.0</flink.version>
 		<flink.shaded.version>15.0</flink.shaded.version>
 
+		<jackson-bom.version>2.13.4.20221013</jackson-bom.version>
 		<junit4.version>4.13.2</junit4.version>
 		<junit5.version>5.8.1</junit5.version>
 		<assertj.version>3.21.0</assertj.version>
@@ -290,7 +291,7 @@ under the License.
 				<artifactId>jackson-bom</artifactId>
 				<type>pom</type>
 				<scope>import</scope>
-				<version>2.13.2.20220328</version>
+				<version>${jackson-bom.version}</version>
 			</dependency>
 
 			<!-- For dependency convergence -->


### PR DESCRIPTION
The PR to upgrade jackson bom to fix CVE-2022-42003 and CVE-2022-42004
It was applied for flink at FLINK-29468 and FLINK-29638

