### PR TITLE
[FLINK-28177] for test containers add elasticsearch service really up check 

### DIFF
--- a/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
+++ b/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
@@ -78,7 +78,7 @@ public class Elasticsearch6DynamicSinkITCase extends TestLogger {
                                     .withMethod("HEAD")
                                     .forStatusCode(200)
                                     .forPort(9200)
-                                    .withStartupTimeout(Duration.ofMinutes(5)));
+                                    .withStartupTimeout(Duration.ofMinutes(2)));
 
     @SuppressWarnings("deprecation")
     protected final RestHighLevelClient getClient() {

--- a/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
+++ b/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
@@ -74,8 +74,7 @@ public class Elasticsearch6DynamicSinkITCase extends TestLogger {
     public static ElasticsearchContainer elasticsearchContainer =
             new ElasticsearchContainer(DockerImageName.parse(DockerImageVersions.ELASTICSEARCH_6))
                     .waitingFor(
-                            forHttp(
-                                    "/")
+                            forHttp("/")
                                     .withMethod("HEAD")
                                     .forStatusCode(200)
                                     .forPort(9200)


### PR DESCRIPTION
## Description
I found elasticsearch service in testcontainers may start up slower than  test case  leading to failure test.
## How to fix
Add a service  check strategy , which is http respose check for elasticsearch. 