### PR TITLE
[hotfix] Disable nighty dependency convergence

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -29,3 +29,4 @@ jobs:
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
+      run_dependency_convergence: false


### PR DESCRIPTION
As per https://github.com/apache/flink-connector-mongodb/commit/a4a3250423592a9bff8859f3132fb72840d0f2b5

Disable dependency convergence for nightly builds to unblock Flink 1.17 build verification