### PR TITLE
[FLINK-31759][es] Update ElasticSearch connector to use sql_connector_download_table shortcode.

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/elasticsearch.md
+++ b/docs/content.zh/docs/connectors/datastream/elasticsearch.md
@@ -42,11 +42,11 @@ under the License.
   <tbody>
     <tr>
         <td>6.x</td>
-        <td>{{< artifact flink-connector-elasticsearch6 >}}</td>
+        <td>{{< connector_artifact flink-connector-elasticsearch6 3.0.0 >}}</td>
     </tr>
     <tr>
         <td>7.x</td>
-        <td>{{< artifact flink-connector-elasticsearch7 >}}</td>
+        <td>{{< connector_artifact flink-connector-elasticsearch7 3.0.0 >}}</td>
     </tr>
   </tbody>
 </table>

--- a/docs/content.zh/docs/connectors/table/elasticsearch.md
+++ b/docs/content.zh/docs/connectors/table/elasticsearch.md
@@ -38,7 +38,7 @@ Elasticsearch 连接器允许将数据写入到 Elasticsearch 引擎的索引中
 依赖
 ------------
 
-{{< sql_download_table "elastic" >}}
+{{< sql_connector_download_table "elastic" 3.0.0 >}}
 
 Elasticsearch 连接器不是二进制发行版的一部分，请查阅[这里]({{< ref "docs/dev/configuration/overview" >}})了解如何在集群运行中引用 Elasticsearch 连接器。
 

--- a/docs/content/docs/connectors/table/elasticsearch.md
+++ b/docs/content/docs/connectors/table/elasticsearch.md
@@ -38,7 +38,7 @@ If no primary key is defined on the DDL, the connector can only operate in appen
 Dependencies
 ------------
 
-{{< sql_download_table "elastic" >}}
+{{< sql_connector_download_table "elastic" 3.0.0 >}}
 
 The Elasticsearch connector is not part of the binary distribution.
 See how to link with it for cluster execution [here]({{< ref "docs/dev/configuration/overview" >}}).

--- a/docs/data/elastic.yml
+++ b/docs/data/elastic.yml
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+variants:
+  - maven: flink-connector-elasticsearch6
+    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch6/$full_version/flink-sql-connector-elasticsearch6-$full_version.jar
+  - maven: flink-connector-elasticsearch7
+    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/$full_version/flink-sql-connector-elasticsearch7-$full_version.jar


### PR DESCRIPTION
- Chinese datastream document also use connector_artifact.
- Update ElasticSearch connector to use sql_connector_download_table shortcode. 

This pr should also backports to v3.0.