### PR TITLE
[FLINK-25568] Support Elasticsearch Source Connector

### DIFF
--- a/flink-connector-elasticsearch-base/pom.xml
+++ b/flink-connector-elasticsearch-base/pom.xml
@@ -164,6 +164,29 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
+			<version>${flink.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- ArchUit test dependencies -->
 
 		<dependency>

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticSearchInputFormatBase.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticSearchInputFormatBase.java
@@ -1,0 +1,230 @@
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.io.LocatableInputSplitAssigner;
+import org.apache.flink.api.common.io.RichInputFormat;
+import org.apache.flink.api.common.io.statistics.BaseStatistics;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputSplitAssigner;
+
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.Scroll;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.shaded.curator5.com.google.common.base.Preconditions.checkNotNull;
+
+@Internal
+public class ElasticSearchInputFormatBase <T, C extends AutoCloseable> extends RichInputFormat<T, ElasticsearchInputSplit>
+        implements ResultTypeQueryable<T> {
+
+
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchInputFormatBase.class);
+    private static final long serialVersionUID = 1L;
+    private final DeserializationSchema<T> deserializationSchema;
+    private final String index;
+    private final String type;
+
+    private final String[] fieldNames;
+    private final QueryBuilder predicate;
+    private final long limit;
+
+    private final long scrollTimeout;
+    private final int scrollSize;
+
+    private Scroll scroll;
+    private String currentScrollWindowId;
+    private String[] currentScrollWindowHits;
+
+    private int nextRecordIndex = 0;
+    private long currentReadCount = 0L;
+
+    /**
+     * Call bridge for different version-specific.
+     */
+    private final ElasticsearchApiCallBridge<C> callBridge;
+
+    private final Map<String, String> userConfig;
+    /**
+     * Elasticsearch client created using the call bridge.
+     */
+    private transient C client;
+
+    public ElasticSearchInputFormatBase(
+            ElasticsearchApiCallBridge<C> callBridge,
+            Map<String, String> userConfig,
+            DeserializationSchema<T> deserializationSchema,
+            String[] fieldNames,
+            String index,
+            String type,
+            long scrollTimeout,
+            int scrollSize,
+            QueryBuilder predicate,
+            long limit) {
+
+        this.callBridge = checkNotNull(callBridge);
+        checkNotNull(userConfig);
+        // copy config so we can remove entries without side-effects
+        this.userConfig = new HashMap<>(userConfig);
+
+        this.deserializationSchema = checkNotNull(deserializationSchema);
+        this.index = index;
+        this.type = type;
+
+        this.fieldNames = fieldNames;
+        this.predicate = predicate;
+        this.limit = limit;
+
+        this.scrollTimeout = scrollTimeout;
+        this.scrollSize = scrollSize;
+
+    }
+    @Override
+    public TypeInformation<T> getProducedType() {
+        return deserializationSchema.getProducedType();
+    }
+
+    @Override
+    public void configure(Configuration configuration) {
+
+        try {
+            client = callBridge.createClient();
+            callBridge.verifyClientConnection(client);
+        } catch (IOException ex) {
+            LOG.error("Exception while creating connection to Elasticsearch.", ex);
+            throw new RuntimeException("Cannot create connection to Elasticsearcg.", ex);
+        }
+    }
+
+    @Override
+    public BaseStatistics getStatistics(BaseStatistics baseStatistics) throws IOException {
+        return null;
+    }
+
+    @Override
+    public ElasticsearchInputSplit[] createInputSplits(int minNumSplits) throws IOException {
+        return callBridge.createInputSplitsInternal(client, index, type, minNumSplits);
+    }
+
+    @Override
+    public InputSplitAssigner getInputSplitAssigner(ElasticsearchInputSplit[] inputSplits) {
+        return new LocatableInputSplitAssigner(inputSplits);
+    }
+
+    @Override
+    public void open(ElasticsearchInputSplit split) throws IOException {
+        SearchRequest searchRequest = new SearchRequest(index);
+        if (type == null) {
+            searchRequest.types(Strings.EMPTY_ARRAY);
+        } else {
+            searchRequest.types(type);
+        }
+        this.scroll = new Scroll(TimeValue.timeValueMinutes(scrollTimeout));
+        searchRequest.scroll(scroll);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        int size;
+        if (limit > 0) {
+            size = (int) Math.min(limit, scrollSize);
+        } else {
+            size = scrollSize;
+        }
+        //elasticsearch default value is 10 here.
+        searchSourceBuilder.size(size);
+        searchSourceBuilder.fetchSource(fieldNames, null);
+        if (predicate != null) {
+            searchSourceBuilder.query(predicate);
+        } else {
+            searchSourceBuilder.query(QueryBuilders.matchAllQuery());
+        }
+        searchRequest.source(searchSourceBuilder);
+        searchRequest.preference("_shards:" + split.getShard());
+        Tuple2<String, String[]> searchResponse = null;
+        try {
+
+            searchResponse = callBridge.search(client, searchRequest);
+        } catch (IOException e) {
+            LOG.error("Search has error: ", e.getMessage());
+        }
+        if (searchResponse != null) {
+            currentScrollWindowId = searchResponse.f0;
+            currentScrollWindowHits = searchResponse.f1;
+            nextRecordIndex = 0;
+        }
+    }
+
+    @Override
+    public boolean reachedEnd() throws IOException {
+        if (limit > 0 && currentReadCount >= limit) {
+            return true;
+        }
+
+        // SearchResponse can be InternalSearchHits.empty(), and the InternalSearchHit[] EMPTY = new InternalSearchHit[0]
+        if (currentScrollWindowHits.length != 0 && nextRecordIndex > currentScrollWindowHits.length - 1) {
+            fetchNextScrollWindow();
+        }
+
+        return currentScrollWindowHits.length == 0;
+    }
+
+    @Override
+    public T nextRecord(T t) throws IOException {
+        if (reachedEnd()) {
+            LOG.warn("Already reached the end of the split.");
+        }
+
+        String hit = currentScrollWindowHits[nextRecordIndex];
+        nextRecordIndex++;
+        currentReadCount++;
+        LOG.debug("Yielding new record for hit: " + hit);
+
+        return parseSearchHit(hit);
+    }
+
+    @Override
+    public void close() throws IOException {
+        callBridge.close(client);
+    }
+
+    private void fetchNextScrollWindow() {
+        Tuple2<String, String[]> searchResponse = null;
+        SearchScrollRequest scrollRequest = new SearchScrollRequest(currentScrollWindowId);
+        scrollRequest.scroll(scroll);
+
+        try {
+            searchResponse = callBridge.scroll(client, scrollRequest);
+        } catch (IOException e) {
+            LOG.error("Scroll failed: " + e.getMessage());
+        }
+
+        if (searchResponse != null) {
+            currentScrollWindowId = searchResponse.f0;
+            currentScrollWindowHits = searchResponse.f1;
+            nextRecordIndex = 0;
+        }
+    }
+
+    private T parseSearchHit(String hit) {
+        T row = null;
+        try {
+            row = deserializationSchema.deserialize(hit.getBytes());
+        } catch (IOException e) {
+            LOG.error("Deserialize search hit failed: " + e.getMessage());
+        }
+
+        return row;
+    }
+}

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
@@ -20,13 +20,18 @@ package org.apache.flink.streaming.connectors.elasticsearch;
 
 import org.apache.flink.annotation.Internal;
 
+import org.apache.flink.api.java.tuple.Tuple2;
+
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchScrollRequest;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -61,12 +66,19 @@ public interface ElasticsearchApiCallBridge<C extends AutoCloseable> extends Ser
      */
     BulkProcessor.Builder createBulkProcessorBuilder(C client, BulkProcessor.Listener listener);
 
+    ElasticsearchInputSplit[] createInputSplitsInternal(C client, String index, String type, int minNumSplits);
+
+    Tuple2<String, String[]> search(C client, SearchRequest searchRequest) throws IOException;
+
+    Tuple2<String, String[]> scroll(C client, SearchScrollRequest searchScrollRequest) throws IOException;
+
+    void close(C client) throws IOException;
+
     /**
      * Extracts the cause of failure of a bulk item action.
      *
      * @param bulkItemResponse the bulk item response to extract cause of failure
-     * @return the extracted {@link Throwable} from the response ({@code null} is the response is
-     *     successful).
+     * @return the extracted {@link Throwable} from the response ({@code null} is the response is successful).
      */
     @Nullable
     Throwable extractFailureCauseFromBulkItemResponse(BulkItemResponse bulkItemResponse);

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchInputSplit.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchInputSplit.java
@@ -1,0 +1,36 @@
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+import org.apache.flink.core.io.LocatableInputSplit;
+
+public class ElasticsearchInputSplit extends LocatableInputSplit {
+
+    private static final long seriaVersionUID = 1L;
+
+    /** The name of the index to retrieve data from. */
+    private final String index;
+
+    /** It is null in flink elasticsearch connector 7+. */
+    private final String type;
+
+    /** Index will split diffirent shards when index created. */
+    private final int shard;
+
+    public ElasticsearchInputSplit(int splitNumber, String[] hostnames, String index, String type, int shard) {
+        super(splitNumber, hostnames);
+        this.index = index;
+        this.type = type;
+        this.shard = shard;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public int getShard() {
+        return shard;
+    }
+}

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchConfiguration.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchConfiguration.java
@@ -38,6 +38,8 @@ import static org.apache.flink.streaming.connectors.elasticsearch.table.Elastics
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.BULK_FLUSH_INTERVAL_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.FAILURE_HANDLER_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.PASSWORD_OPTION;
+import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.SCROLL_MAX_SIZE_OPTION;
+import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.SCROLL_TIMEOUT_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.USERNAME_OPTION;
 
 /** Accessor methods to elasticsearch options. */
@@ -148,6 +150,26 @@ class ElasticsearchConfiguration {
 
     public Optional<String> getPathPrefix() {
         return config.getOptional(ElasticsearchConnectorOptions.CONNECTION_PATH_PREFIX);
+    }
+
+    public Optional<Integer> getScrollMaxSize() {
+        return config.getOptional(SCROLL_MAX_SIZE_OPTION);
+    }
+
+    public Optional<Long> getScrollTimeout() {
+        return config.getOptional(SCROLL_TIMEOUT_OPTION).map(Duration::toMillis);
+    }
+
+    public long getCacheMaxSize() {
+        return config.get(ElasticsearchConnectorOptions.LOOKUP_CACHE_MAX_ROWS);
+    }
+
+    public Duration getCacheExpiredMs() {
+        return config.get(ElasticsearchConnectorOptions.LOOKUP_CACHE_TTL);
+    }
+
+    public int getMaxRetryTimes() {
+        return config.get(ElasticsearchConnectorOptions.LOOKUP_MAX_RETRIES);
     }
 
     @Override

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchConnectorOptions.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchConnectorOptions.java
@@ -77,6 +77,19 @@ public class ElasticsearchConnectorOptions {
                     .withDescription(
                             "Delimiter for composite keys e.g., \"$\" would result in IDs \"KEY1$KEY2$KEY3\".");
 
+    // elasticsearch source config options
+    public static final ConfigOption<Integer> SCROLL_MAX_SIZE_OPTION =
+            ConfigOptions.key("scan.scroll.max-size")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription("Maximum number of hits to be returned with each Elasticsearch scroll request");
+
+    public static final ConfigOption<Duration> SCROLL_TIMEOUT_OPTION =
+            ConfigOptions.key("scan.scroll.timeout")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription("Amount of time Elasticsearch will keep the search context alive for scroll requests");
+
     public static final ConfigOption<String> FAILURE_HANDLER_OPTION =
             ConfigOptions.key("failure-handler")
                     .stringType()
@@ -152,6 +165,24 @@ public class ElasticsearchConnectorOptions {
                             "The format must produce a valid JSON document. "
                                     + "Please refer to the documentation on formats for more details.");
 
+    // look up config options
+    public static final ConfigOption<Long> LOOKUP_CACHE_MAX_ROWS = ConfigOptions
+            .key("lookup.cache.max-rows")
+            .longType()
+            .defaultValue(-1L)
+            .withDescription("the max number of rows of lookup cache, over this value, the oldest rows will " +
+                    "be eliminated. \"cache.max-rows\" and \"cache.ttl\" options must all be specified if any of them is " +
+                    "specified. Cache is not enabled as default.");
+    public static final ConfigOption<Duration> LOOKUP_CACHE_TTL = ConfigOptions
+            .key("lookup.cache.ttl")
+            .durationType()
+            .defaultValue(Duration.ofSeconds(10))
+            .withDescription("the cache time to live.");
+    public static final ConfigOption<Integer> LOOKUP_MAX_RETRIES = ConfigOptions
+            .key("lookup.max-retries")
+            .intType()
+            .defaultValue(3)
+            .withDescription("the max retry times if lookup database failed.");
     // --------------------------------------------------------------------------------------------
     // Enums
     // --------------------------------------------------------------------------------------------

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchLookupOptions.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchLookupOptions.java
@@ -1,0 +1,84 @@
+package org.apache.flink.streaming.connectors.elasticsearch.table;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ElasticsearchLookupOptions implements Serializable {
+
+    private final long cacheMaxSize;
+    private final long cacheExpireMs;
+    private final int maxRetryTimes;
+
+    public ElasticsearchLookupOptions(long cacheMaxSize, long cacheExpireMs, int maxRetryTimes) {
+        this.cacheMaxSize = cacheMaxSize;
+        this.cacheExpireMs = cacheExpireMs;
+        this.maxRetryTimes = maxRetryTimes;
+    }
+
+    public long getCacheMaxSize() {
+        return cacheMaxSize;
+    }
+
+    public long getCacheExpireMs() {
+        return cacheExpireMs;
+    }
+
+    public int getMaxRetryTimes() {
+        return maxRetryTimes;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof ElasticsearchLookupOptions) {
+            ElasticsearchLookupOptions options = (ElasticsearchLookupOptions) o;
+            return Objects.equals(cacheMaxSize, options.cacheMaxSize) &&
+                    Objects.equals(cacheExpireMs, options.cacheExpireMs) &&
+                    Objects.equals(maxRetryTimes, options.maxRetryTimes);
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Builder of {@link ElasticsearchLookupOptions}.
+     */
+    public static class Builder {
+        private long cacheMaxSize = -1L;
+        private long cacheExpireMs = -1L;
+        private int maxRetryTimes = 3;
+
+        /**
+         * optional, lookup cache max size, over this value, the old data will be eliminated.
+         */
+        public Builder setCacheMaxSize(long cacheMaxSize) {
+            this.cacheMaxSize = cacheMaxSize;
+            return this;
+        }
+
+        /**
+         * optional, lookup cache expire mills, over this time, the old data will expire.
+         */
+        public Builder setCacheExpireMs(long cacheExpireMs) {
+            this.cacheExpireMs = cacheExpireMs;
+            return this;
+        }
+
+        /**
+         * optional, max retry times for jdbc connector.
+         */
+        public Builder setMaxRetryTimes(int maxRetryTimes) {
+            this.maxRetryTimes = maxRetryTimes;
+            return this;
+        }
+
+        public ElasticsearchLookupOptions build() {
+            return new ElasticsearchLookupOptions(cacheMaxSize, cacheExpireMs, maxRetryTimes);
+        }
+    }
+
+
+}

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchRowDataLookupFunction.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchRowDataLookupFunction.java
@@ -1,0 +1,202 @@
+package org.apache.flink.streaming.connectors.elasticsearch.table;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchApiCallBridge;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.table.data.util.DataFormatConverters.DataFormatConverter;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.TableFunction;
+
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
+
+import org.apache.flink.util.Preconditions;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.cache.CacheBuilder;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.elasticsearch.common.cache.CacheBuilder.builder;
+
+public class ElasticsearchRowDataLookupFunction<C extends AutoCloseable> extends TableFunction<RowData> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchRowDataLookupFunction.class);
+
+    private final DeserializationSchema<RowData> deserializationSchema;
+
+    private final String index;
+
+    private final String type;
+
+    private final String[] producedNames;
+
+    private final String[] lookupKeys;
+
+    // converters to convert data from internal to external in order to generate keys for the cache.
+    private final DataFormatConverter[] converters;
+    private SearchRequest searchRequest;
+    private SearchSourceBuilder searchSourceBuilder;
+    private final long cacheMaxSize;
+    private final long cacheExpireMs;
+    private final long maxRetryTimes;
+    private final ElasticsearchApiCallBridge<C> callBridge;
+
+    private transient C client;
+    private transient Cache<RowData, List<RowData>> cache;
+
+    public ElasticsearchRowDataLookupFunction(
+            DeserializationSchema<RowData> deserializationSchema,
+            ElasticsearchLookupOptions lookupOptions,
+            String index,
+            String type,
+            String[] producedNames,
+            DataType[] producedTypes,
+            String[] lookupKeys,
+            ElasticsearchApiCallBridge<C> callBridge) {
+
+        checkNotNull(deserializationSchema, "No DeserializationSchema supplied.");
+        checkNotNull(lookupOptions, "No ElasticsearchLookupOptions supplied.");
+        checkNotNull(producedNames, "No fieldNames supplied.");
+        checkNotNull(producedTypes, "No fieldTypes supplied.");
+        checkNotNull(lookupKeys, "No keyNames supplied.");
+        checkNotNull(callBridge, "No ElasticsearchApiCallBridge supplied.");
+
+        this.deserializationSchema = deserializationSchema;
+        this.cacheExpireMs = lookupOptions.getCacheExpireMs();
+        this.cacheMaxSize = lookupOptions.getCacheMaxSize();
+        this.maxRetryTimes = lookupOptions.getMaxRetryTimes();
+
+        this.index = index;
+        this.type = type;
+        this.producedNames = producedNames;
+        this.lookupKeys = lookupKeys;
+        this.converters = new DataFormatConverter[lookupKeys.length];
+        Map<String, Integer> nameToIndex = IntStream.range(0, producedNames.length).boxed().collect(
+                Collectors.toMap(i -> producedNames[i], i -> i));
+        for (int i = 0; i < lookupKeys.length; i++) {
+            Integer position = nameToIndex.get(lookupKeys[i]);
+            Preconditions.checkArgument(position != null, "Lookup keys %s not selected", Arrays.toString(lookupKeys));
+            converters[i] = DataFormatConverters.getConverterForDataType(producedTypes[position]);
+        }
+        this.callBridge = callBridge;
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        this.cache = cacheMaxSize == -1 || cacheExpireMs == -1 ? null : CacheBuilder.<RowData, List<RowData>>builder().setExpireAfterWrite(TimeValue.timeValueMillis(cacheExpireMs))
+                .setMaximumWeight(cacheMaxSize).build();
+        this.client = callBridge.createClient();
+        //Set searchRequest in open method in case of amount of calling in eval method when every record comes.
+        this.searchRequest = new SearchRequest(index);
+        if (type == null) {
+            searchRequest.types(Strings.EMPTY_ARRAY);
+        } else {
+            searchRequest.types(type);
+        }
+        searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.fetchSource(producedNames, null);
+    }
+
+
+    /**
+     * This is a lookup method which is called by Flink framework in runtime.
+     *
+     * @param keys lookup keys
+     */
+    public void eval(Object... keys) {
+        RowData keyRow = GenericRowData.of(keys);
+        if (cache != null) {
+            List<RowData> cachedRows = cache.get(keyRow);
+            if (cachedRows != null) {
+                for (RowData cachedRow : cachedRows) {
+                    collect(cachedRow);
+                }
+                return;
+            }
+        }
+
+        BoolQueryBuilder lookupCondition = new BoolQueryBuilder();
+        for (int i = 0; i < lookupKeys.length; i++) {
+            lookupCondition.must(new TermQueryBuilder(lookupKeys[i], converters[i].toExternal(keys[i])));
+        }
+        searchSourceBuilder.query(lookupCondition);
+        searchRequest.source(searchSourceBuilder);
+
+        Tuple2<String, String[]> searchResponse = null;
+
+        for (int retry = 1; retry <= maxRetryTimes; retry++) {
+            try {
+                searchResponse = callBridge.search(client, searchRequest);
+                if (searchResponse.f1.length > 0) {
+                    String[] result = searchResponse.f1;
+                    // if cache disabled
+                    if (cache == null) {
+                        for (int i = 0; i < result.length; i++) {
+                            RowData row = parseSearchHit(result[i]);
+                            collect(row);
+                        }
+                    } else { // if cache enabled
+                        ArrayList<RowData> rows = new ArrayList<>();
+                        for (int i = 0; i < result.length; i++) {
+                            RowData row = parseSearchHit(result[i]);
+                            collect(row);
+                            rows.add(row);
+                        }
+                        cache.put(keyRow, rows);
+                    }
+                }
+                break;
+            } catch (IOException e) {
+                LOG.error(String.format("Elasticsearch search error, retry times = %d", retry), e);
+                if (retry >= maxRetryTimes) {
+                    throw new RuntimeException("Execution of Elasticsearch search failed.", e);
+                }
+                try {
+                    Thread.sleep(1000 * retry);
+                } catch (InterruptedException e1) {
+                    LOG.warn("Interrupted while waiting to retry failed elasticsearch search, aborting");
+                    throw new RuntimeException(e1);
+                }
+            }
+        }
+    }
+
+    private RowData parseSearchHit(String hit) {
+        RowData row = null;
+        try {
+            row = deserializationSchema.deserialize(hit.getBytes());
+        } catch (IOException e) {
+            LOG.error("Deserialize search hit failed: " + e.getMessage());
+        }
+
+        return row;
+    }
+
+
+
+
+
+
+
+
+}

--- a/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
+++ b/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.elasticsearch;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.core.testutils.MultiShotLatch;
@@ -35,6 +36,8 @@ import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.junit.Test;
@@ -43,6 +46,7 @@ import org.mockito.stubbing.Answer;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -601,6 +605,33 @@ public class ElasticsearchSinkBaseTest {
         public BulkProcessor.Builder createBulkProcessorBuilder(
                 Client client, BulkProcessor.Listener listener) {
             return null;
+        }
+
+        @Override
+        public ElasticsearchInputSplit[] createInputSplitsInternal(
+                Client client,
+                String index,
+                String type,
+                int minNumSplits) {
+            return new ElasticsearchInputSplit[0];
+        }
+
+        @Override
+        public Tuple2<String, String[]> search(Client client, SearchRequest searchRequest)
+                throws IOException {
+            return null;
+        }
+
+        @Override
+        public Tuple2<String, String[]> scroll(
+                Client client,
+                SearchScrollRequest searchScrollRequest) throws IOException {
+            return null;
+        }
+
+        @Override
+        public void close(Client client) throws IOException {
+
         }
 
         @Nullable

--- a/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkTestBase.java
@@ -17,20 +17,38 @@
 
 package org.apache.flink.streaming.connectors.elasticsearch;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.planner.runtime.utils.TestingAppendRowDataSink;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.formats.json.JsonRowDataDeserializationSchema;
 import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.elasticsearch.testutils.SourceSinkDataTestKit;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.test.util.AbstractTestBase;
 
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.QueryBuilder;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.STRING;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Environment preparation and suite of tests for version-specific {@link ElasticsearchSinkBase}
@@ -39,8 +57,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @param <C> Elasticsearch client type
  * @param <A> The address type to use
  */
-public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A>
+public abstract class ElasticsearchSinkTestBase<T, C extends AutoCloseable, A>
         extends AbstractTestBase {
+
+    protected static final String CLUSTER_NAME = "test-cluster";
 
     protected abstract RestHighLevelClient getClient();
 
@@ -76,6 +96,74 @@ public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A>
 
         client.close();
     }
+
+    protected void runElasticSearchInputFormatTest() throws Exception {
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        Map<String, String> userConfig = new HashMap<>();
+        userConfig.put("cluster.name", CLUSTER_NAME);
+        DataType dataType = ROW(FIELD("data", STRING()));
+        RowType schema = (RowType) dataType.getLogicalType();
+
+        // pass on missing field
+        DeserializationSchema<RowData> deserializationSchema = new JsonRowDataDeserializationSchema(
+                schema, InternalTypeInfo.of(schema), false, false, TimestampFormat.ISO_8601);
+
+        ElasticSearchInputFormatBase inputFormat = createElasticsearchInputFormat(
+                userConfig,
+                (DeserializationSchema<T>) deserializationSchema,
+                null,
+                "elasticsearch-sink-test-json-index",
+                "flink-es-test-type",
+                1000,
+                10,
+                null,
+                0
+        );
+
+        DataStream<RowData> dataStream = env.createInput(inputFormat);
+        TestingAppendRowDataSink sink = new TestingAppendRowDataSink(InternalTypeInfo.of(schema));
+        dataStream.addSink(sink);
+        env.execute("Elasticsearch Source Test");
+        List<String> expected = Arrays.asList(
+                "+I(message #0)",
+                "+I(message #1)",
+                "+I(message #10)",
+                "+I(message #11)",
+                "+I(message #12)",
+                "+I(message #13)",
+                "+I(message #14)",
+                "+I(message #15)",
+                "+I(message #16)",
+                "+I(message #17)",
+                "+I(message #18)",
+                "+I(message #19)",
+                "+I(message #2)",
+                "+I(message #3)",
+                "+I(message #4)",
+                "+I(message #5)",
+                "+I(message #6)",
+                "+I(message #7)",
+                "+I(message #8)",
+                "+I(message #9)"
+        );
+        List<String> results = sink.getJavaAppendResults();
+        results.sort(String::compareTo);
+        assertEquals(expected, results);
+    }
+
+    protected abstract ElasticSearchInputFormatBase createElasticsearchInputFormat(
+            Map<String, String> userConfig,
+            DeserializationSchema<T> deserializationSchema,
+            String[] fieldNames,
+            String index,
+            String type,
+            long scrollTimeout,
+            int scrollMaxSize,
+            QueryBuilder predicate,
+            int limit
+    ) throws Exception;
 
     /**
      * Tests that the Elasticsearch sink fails eagerly if the provided list of addresses is {@code

--- a/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6ApiCallBridge.java
+++ b/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6ApiCallBridge.java
@@ -18,7 +18,9 @@
 package org.apache.flink.streaming.connectors.elasticsearch6;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchApiCallBridge;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchInputSplit;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
 import org.apache.flink.util.Preconditions;
@@ -27,6 +29,8 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -38,6 +42,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /** Implementation of {@link ElasticsearchApiCallBridge} for Elasticsearch 6 and later versions. */
@@ -76,6 +81,33 @@ public class Elasticsearch6ApiCallBridge
     public BulkProcessor.Builder createBulkProcessorBuilder(
             RestHighLevelClient client, BulkProcessor.Listener listener) {
         return BulkProcessor.builder(client::bulkAsync, listener);
+    }
+
+    @Override
+    public ElasticsearchInputSplit[] createInputSplitsInternal(
+            RestHighLevelClient client,
+            String index,
+            String type,
+            int minNumSplits) {
+        return new ElasticsearchInputSplit[0];
+    }
+
+    @Override
+    public Tuple2<String, String[]> search(RestHighLevelClient client, SearchRequest searchRequest)
+            throws IOException {
+        return null;
+    }
+
+    @Override
+    public Tuple2<String, String[]> scroll(
+            RestHighLevelClient client,
+            SearchScrollRequest searchScrollRequest) throws IOException {
+        return null;
+    }
+
+    @Override
+    public void close(RestHighLevelClient client) throws IOException {
+
     }
 
     @Override

--- a/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSource.java
+++ b/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSource.java
@@ -1,0 +1,99 @@
+package org.apache.flink.streaming.connectors.elasticsearch.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.streaming.connectors.elasticsearch7.Elasticsearch7ApiCallBridge;
+import org.apache.flink.streaming.connectors.elasticsearch7.RestClientFactory;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.TableFunctionProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.Preconditions;
+
+@Internal
+public class Elasticsearch7DynamicSource implements ScanTableSource, LookupTableSource,
+        SupportsProjectionPushDown {
+
+    private final DecodingFormat<DeserializationSchema<RowData>> format;
+    private final Elasticsearch7Configuration config;
+    private final ElasticsearchLookupOptions lookupOptions;
+    private TableSchema physicalSchema;
+
+    public Elasticsearch7DynamicSource(
+            DecodingFormat<DeserializationSchema<RowData>> format,
+            Elasticsearch7Configuration config,
+            TableSchema physicalSchema,
+            ElasticsearchLookupOptions lookupOptions) {
+        this.format = format;
+        this.config = config;
+        this.physicalSchema = physicalSchema;
+        this.lookupOptions = lookupOptions;
+    }
+
+    @Override
+    public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext lookupContext) {
+        RestClientFactory restClientFactory = null;
+        if (config.getPathPrefix().isPresent()) {
+            restClientFactory = new Elasticsearch7DynamicSink.DefaultRestClientFactory(config.getPathPrefix().get());
+        } else {
+            restClientFactory = restClientBuilder -> {};
+        }
+
+        Elasticsearch7ApiCallBridge elasticsearch7ApiCallBridge = new Elasticsearch7ApiCallBridge(
+                config.getHosts(), restClientFactory);
+
+        // Elasticsearch only support non-nested look up keys
+        String[] lookupKeys = new String[lookupContext.getKeys().length];
+        String [] columnNames = physicalSchema.getFieldNames();
+        for (int i = 0; i < lookupKeys.length; i++) {
+            int[] innerKeyArr = lookupContext.getKeys()[i];
+            Preconditions.checkArgument(innerKeyArr.length == 1, "Elasticsearch only support non-nested look up keys");
+            lookupKeys[i] = columnNames[innerKeyArr[0]];
+        }
+        DataType[] columnDataTypes = physicalSchema.getFieldDataTypes();
+
+        return TableFunctionProvider.of(new ElasticsearchRowDataLookupFunction(
+                this.format.createRuntimeDecoder(lookupContext, physicalSchema.toRowDataType()),
+                        lookupOptions,
+                        config.getIndex(),
+                        config.getDocumentType(),
+                        columnNames,
+                        columnDataTypes,
+                        lookupKeys,
+                        elasticsearch7ApiCallBridge
+        ));
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return ChangelogMode.insertOnly();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext scanContext) {
+        return null;
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        return null;
+    }
+
+    @Override
+    public String asSummaryString() {
+        return null;
+    }
+
+    @Override
+    public boolean supportsNestedProjection() {
+        return false;
+    }
+}

--- a/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticSearch7InputFormat.java
+++ b/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticSearch7InputFormat.java
@@ -1,0 +1,143 @@
+package org.apache.flink.streaming.connectors.elasticsearch7;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticSearchInputFormatBase;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.QueryBuilder;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@PublicEvolving
+public class ElasticSearch7InputFormat<T> extends
+        ElasticSearchInputFormatBase<T, RestHighLevelClient> {
+
+    private static final long serialVersionUID = 1L;
+
+    public ElasticSearch7InputFormat(
+            Map<String, String> userConfig,
+            List<HttpHost> httpHosts,
+            RestClientFactory restClientFactory,
+            DeserializationSchema<T> serializationSchema,
+            String[] fieldNames,
+            String index,
+            long scrollTimeout,
+            int scrollSize,
+            QueryBuilder predicate,
+            int limit) {
+
+        super(new Elasticsearch7ApiCallBridge(httpHosts, restClientFactory), userConfig, serializationSchema, fieldNames, index, null, scrollTimeout, scrollSize, predicate, limit);
+    }
+
+    /**
+     * A builder for creating an {@link ElasticSearch7InputFormat}.
+     *
+     * @param <T> Type of the elements.
+     */
+    @PublicEvolving
+    public static class Builder<T> {
+        private Map<String, String> userConfig = new HashMap<>();
+        private List<HttpHost> httpHosts;
+        private RestClientFactory restClientFactory = restClientBuilder -> {
+        };
+        private DeserializationSchema<T> deserializationSchema;
+        private String index;
+
+        private long scrollTimeout;
+        private int scrollMaxSize;
+
+        private String[] fieldNames;
+        private QueryBuilder predicate;
+        private int limit;
+
+        public Builder() {
+        }
+
+        /**
+         * Sets HttpHost which the RestHighLevelClient connects to.
+         *
+         * @param httpHosts The list of {@link HttpHost} to which the {@link RestHighLevelClient} connects to.
+         */
+        public Builder setHttpHosts(List<HttpHost> httpHosts) {
+            this.httpHosts = httpHosts;
+            return this;
+        }
+
+        /**
+         * Sets a REST client factory for custom client configuration.
+         *
+         * @param restClientFactory the factory that configures the rest client.
+         */
+        public Builder setRestClientFactory(RestClientFactory restClientFactory) {
+            this.restClientFactory = Preconditions.checkNotNull(restClientFactory);
+            return this;
+        }
+
+        public Builder setDeserializationSchema(DeserializationSchema<T> deserializationSchema) {
+            this.deserializationSchema = deserializationSchema;
+            return this;
+        }
+
+        public Builder setIndex(String index) {
+            this.index = index;
+            return this;
+        }
+
+        /**
+         * Sets the maxinum number of each Elasticsearch scroll request.
+         *
+         * @param scrollMaxSize the maxinum number of each Elasticsearch scroll request.
+         */
+        public Builder setScrollMaxSize(int scrollMaxSize) {
+            Preconditions.checkArgument(
+                    scrollMaxSize > 0,
+                    "Maximum number each Elasticsearch scroll request must be larger than 0.");
+
+            this.scrollMaxSize = scrollMaxSize;
+            return this;
+        }
+
+        /**
+         * Sets the search context alive for scroll requests, in milliseconds.
+         *
+         * @param scrollTimeout the search context alive for scroll requests, in milliseconds.
+         */
+        public Builder setScrollTimeout(long scrollTimeout) {
+            Preconditions.checkArgument(
+                    scrollTimeout >= 0,
+                    "Yhe search context alive for scroll requests must be larger than or equal to 0.");
+
+            this.scrollTimeout = scrollTimeout;
+            return this;
+        }
+
+        public Builder setFieldNames(String[] fieldNames) {
+            this.fieldNames = fieldNames;
+            return this;
+        }
+
+        public Builder setPredicate(QueryBuilder predicate) {
+            this.predicate = predicate;
+            return this;
+        }
+
+        public Builder setLimit(int limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        /**
+         * Creates the ElasticSearch7RowDataInputFormat.
+         *
+         * @return the created ElasticSearch7RowDataInputFormat.
+         */
+        public ElasticSearch7InputFormat<T> build() {
+            return new ElasticSearch7InputFormat<T>(userConfig, httpHosts, restClientFactory, deserializationSchema, fieldNames, index, scrollTimeout, scrollMaxSize, predicate, limit);
+        }
+    }
+}

--- a/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7ApiCallBridge.java
+++ b/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7ApiCallBridge.java
@@ -18,7 +18,12 @@
 package org.apache.flink.streaming.connectors.elasticsearch7;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchApiCallBridge;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchInputSplit;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
 import org.apache.flink.util.Preconditions;
@@ -27,6 +32,8 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
@@ -56,7 +63,9 @@ public class Elasticsearch7ApiCallBridge
     /** The factory to configure the rest client. */
     private final RestClientFactory restClientFactory;
 
-    Elasticsearch7ApiCallBridge(List<HttpHost> httpHosts, RestClientFactory restClientFactory) {
+    private final ObjectMapper jsonParser = new ObjectMapper();
+
+    public Elasticsearch7ApiCallBridge(List<HttpHost> httpHosts, RestClientFactory restClientFactory) {
         Preconditions.checkArgument(httpHosts != null && !httpHosts.isEmpty());
         this.httpHosts = httpHosts;
         this.restClientFactory = Preconditions.checkNotNull(restClientFactory);
@@ -80,6 +89,33 @@ public class Elasticsearch7ApiCallBridge
                 (request, bulkListener) ->
                         client.bulkAsync(request, RequestOptions.DEFAULT, bulkListener),
                 listener);
+    }
+
+    @Override
+    public ElasticsearchInputSplit[] createInputSplitsInternal(
+            RestHighLevelClient client,
+            String index,
+            String type,
+            int minNumSplits) {
+        return new ElasticsearchInputSplit[0];
+    }
+
+    @Override
+    public Tuple2<String, String[]> search(RestHighLevelClient client, SearchRequest searchRequest)
+            throws IOException {
+        return null;
+    }
+
+    @Override
+    public Tuple2<String, String[]> scroll(
+            RestHighLevelClient client,
+            SearchScrollRequest searchScrollRequest) throws IOException {
+        return null;
+    }
+
+    @Override
+    public void close(RestHighLevelClient client) throws IOException {
+
     }
 
     @Override

--- a/flink-connector-elasticsearch7/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connector-elasticsearch7/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.streaming.connectors.elasticsearch.table.Elasticsearch7DynamicSinkFactory
+org.apache.flink.streaming.connectors.elasticsearch.table.Elasticsearch7DynamicTableFactory

--- a/flink-connector-elasticsearch7/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch7DynamicTableFactoryTest.java
+++ b/flink-connector-elasticsearch7/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch7DynamicTableFactoryTest.java
@@ -26,7 +26,7 @@ import static org.apache.flink.connector.elasticsearch.table.TestContext.context
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for validation in {@link Elasticsearch7DynamicSinkFactory}. */
-public class Elasticsearch7DynamicSinkFactoryTest extends ElasticsearchDynamicSinkFactoryBaseTest {
+public class Elasticsearch7DynamicTableFactoryTest extends ElasticsearchDynamicSinkFactoryBaseTest {
     @Override
     ElasticsearchDynamicSinkFactoryBase createSinkFactory() {
         return new Elasticsearch7DynamicSinkFactory();

--- a/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
+++ b/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.TestLogger;
 
@@ -63,22 +64,15 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.apache.flink.streaming.connectors.elasticsearch.table.Elasticsearch7DynamicTableTestBase.elasticsearchContainer;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.TestContext.context;
 import static org.apache.flink.table.api.Expressions.row;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT tests for {@link Elasticsearch7DynamicSink}. */
-public class Elasticsearch7DynamicSinkITCase extends TestLogger {
+public class Elasticsearch7DynamicSinkITCase extends Elasticsearch7DynamicTableTestBase {
 
-    @ClassRule
-    public static ElasticsearchContainer elasticsearchContainer =
-            new ElasticsearchContainer(DockerImageName.parse(DockerImageVersions.ELASTICSEARCH_7));
 
-    @SuppressWarnings("deprecation")
-    protected final RestHighLevelClient getClient() {
-        return new RestHighLevelClient(
-                RestClient.builder(HttpHost.create(elasticsearchContainer.getHttpHostAddress())));
-    }
 
     @Test
     public void testWritingDocuments() throws Exception {
@@ -107,7 +101,7 @@ public class Elasticsearch7DynamicSinkITCase extends TestLogger {
                                 LocalDateTime.parse("2012-12-12T12:12:12")));
 
         String index = "writing-documents";
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory sinkFactory = new Elasticsearch7DynamicTableFactory();
 
         SinkFunctionProvider sinkRuntimeProvider =
                 (SinkFunctionProvider)

--- a/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSourceITCase.java
+++ b/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSourceITCase.java
@@ -1,0 +1,82 @@
+package org.apache.flink.streaming.connectors.elasticsearch.table;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import static org.junit.Assert.assertTrue;
+
+public class Elasticsearch7DynamicSourceITCase extends Elasticsearch7DynamicTableTestBase {
+
+    private final String scanKeywordIndex = "scan-keyword-index";
+    private final String scanKeywordType = "scan-keyword-type";
+
+    @Before
+    public void before() throws IOException, ExecutionException, InterruptedException {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        assertTrue(createIndex(getClient(), scanKeywordIndex, scanKeywordType, "keyword"));
+        insertData(tEnv, scanKeywordIndex, scanKeywordType);
+    }
+
+    @Test
+    public void testElasticsearchSource() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        tEnv.executeSql("CREATE TABLE esTableSource (" +
+                "a BIGINT NOT NULL,\n" +
+                "b STRING NOT NULL,\n" +
+                "c FLOAT,\n" +
+                "d TINYINT NOT NULL,\n" +
+                "e TIME,\n" +
+                "f DATE,\n" +
+                "g TIMESTAMP NOT NULL,\n" +
+                "h as a + 2,\n" +
+                "PRIMARY KEY (c, d) NOT ENFORCED\n" +
+                ")\n" +
+                "WITH (\n" +
+                String.format("'%s'='%s',\n", "connector", "elasticsearch-7") +
+                String.format("'%s'='%s',\n", ElasticsearchConnectorOptions.INDEX_OPTION.key(), scanKeywordIndex) +
+                String.format("'%s'='%s',\n", ElasticsearchConnectorOptions.HOSTS_OPTION.key(), "http://127.0.0.1:9200") +
+                String.format("'%s'='%s',\n", ElasticsearchConnectorOptions.SCROLL_MAX_SIZE_OPTION.key(), 10) +
+                String.format("'%s'='%s'\n", ElasticsearchConnectorOptions.SCROLL_TIMEOUT_OPTION.key(), 1000) +
+                ")");
+
+        Iterator<Row> collected = tEnv.executeSql("SELECT a, b, c, d, e, f, g, h FROM esTableSource").collect();
+        List<String> result = Lists.newArrayList(collected).stream()
+                .map(Row::toString)
+                .sorted()
+                .collect(Collectors.toList());
+
+        List<String> expected =
+                Stream.of(
+                        "1,A B,12.1,2,00:00:12,2003-10-20,2012-12-12T12:12:12,3",
+                        "1,A,12.11,2,00:00:12,2003-10-20,2012-12-12T12:12:12,3",
+                        "1,A,12.12,2,00:00:12,2003-10-20,2012-12-12T12:12:12,3",
+                        "2,B,12.13,3,00:00:12,2003-10-21,2012-12-12T12:12:13,4",
+                        "3,C,12.14,4,00:00:12,2003-10-22,2012-12-12T12:12:14,5",
+                        "4,D,12.15,5,00:00:12,2003-10-23,2012-12-12T12:12:15,6",
+                        "5,E,12.16,6,00:00:12,2003-10-24,2012-12-12T12:12:16,7")
+                        .sorted()
+                        .collect(
+                                Collectors.toList()
+                        );
+        assertEquals(expected, result);
+    }
+
+}

--- a/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicTableFactoryTest.java
+++ b/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicTableFactoryTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.elasticsearch.table;
 
 import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -76,6 +77,91 @@ public class Elasticsearch7DynamicTableFactoryTest extends TestLogger {
                 "Could not parse host 'wrong-host' in option 'hosts'. It should follow the format 'http://host_name:port'.");
         sinkFactory.createDynamicTableSink(
                 context().withOption("index", "MyIndex").withOption("hosts", "wrong-host").build());
+    }
+
+    @Test
+    public void validateWrongScrollMaxSize() {
+        Elasticsearch7DynamicTableFactory tableFactory = new Elasticsearch7DynamicTableFactory();
+
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage(
+                "'scan.scroll.max-size' must be at least 1. Got: 0");
+        tableFactory.createDynamicTableSource(
+                context()
+                        .withSchema(ResolvedSchema.of(Column.physical("a", DataTypes.TIME())))
+                        .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
+                        .withOption(ElasticsearchConnectorOptions.HOSTS_OPTION.key(), "http://localhost:1234")
+                        .withOption(ElasticsearchConnectorOptions.SCROLL_MAX_SIZE_OPTION.key(), "0")
+                        .build()
+        );
+    }
+
+    @Test
+    public void validateWrongScrollTimeout() {
+        Elasticsearch7DynamicTableFactory tableFactory = new Elasticsearch7DynamicTableFactory();
+
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage(
+                "'scan.scroll.timeout' must be at least 1. Got: 0");
+        tableFactory.createDynamicTableSource(
+                context()
+                        .withSchema(ResolvedSchema.of(Column.physical("a", DataTypes.TIME())))
+                        .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
+                        .withOption(ElasticsearchConnectorOptions.HOSTS_OPTION.key(), "http://localhost:1234")
+                        .withOption(ElasticsearchConnectorOptions.SCROLL_TIMEOUT_OPTION.key(), "0")
+                        .build()
+        );
+    }
+
+    @Test
+    public void validateWrongCacheMaxSize() {
+        Elasticsearch7DynamicTableFactory tableFactory = new Elasticsearch7DynamicTableFactory();
+
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage(
+                "'lookup.cache.max-rows' must be at least 1. Got: 0");
+        tableFactory.createDynamicTableSource(
+                context()
+                        .withSchema(ResolvedSchema.of(Column.physical("a", DataTypes.TIME())))
+                        .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
+                        .withOption(ElasticsearchConnectorOptions.HOSTS_OPTION.key(), "http://localhost:1234")
+                        .withOption(ElasticsearchConnectorOptions.LOOKUP_CACHE_MAX_ROWS.key(), "0")
+                        .build()
+        );
+    }
+
+    @Test
+    public void validateWrongCacheTTL() {
+        Elasticsearch7DynamicTableFactory tableFactory = new Elasticsearch7DynamicTableFactory();
+
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage(
+                "'lookup.cache.ttl' must be at least 1. Got: 0");
+        tableFactory.createDynamicTableSource(
+                context()
+                        .withSchema(ResolvedSchema.of(Column.physical("a", DataTypes.TIME())))
+                        .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
+                        .withOption(ElasticsearchConnectorOptions.HOSTS_OPTION.key(), "http://localhost:1234")
+                        .withOption(ElasticsearchConnectorOptions.LOOKUP_CACHE_TTL.key(), "0")
+                        .build()
+        );
+    }
+
+    @Test
+    public void validateWrongMaxRetries() {
+        Elasticsearch7DynamicTableFactory tableFactory = new Elasticsearch7DynamicTableFactory();
+
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage(
+                "'lookup.max-retries' must be at least 1. Got: 0");
+        tableFactory.createDynamicTableSource(
+                context()
+                        .withSchema(ResolvedSchema.of(Column.physical("a", DataTypes.TIME())))
+                        .withOption(ElasticsearchConnectorOptions.INDEX_OPTION.key(), "MyIndex")
+                        .withOption(ElasticsearchConnectorOptions.HOSTS_OPTION.key(), "http://localhost:1234")
+                        .withOption(ElasticsearchConnectorOptions.LOOKUP_MAX_RETRIES.key(), "0")
+                        .build()
+        );
     }
 
     @Test

--- a/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicTableFactoryTest.java
+++ b/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicTableFactoryTest.java
@@ -35,13 +35,13 @@ import java.util.Collections;
 
 import static org.apache.flink.streaming.connectors.elasticsearch.table.TestContext.context;
 
-/** Tests for validation in {@link Elasticsearch7DynamicSinkFactory}. */
-public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
+/** Tests for validation in {@link Elasticsearch7DynamicTableFactory}. */
+public class Elasticsearch7DynamicTableFactoryTest extends TestLogger {
     @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void validateEmptyConfiguration() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory sinkFactory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
@@ -56,7 +56,7 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongIndex() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory sinkFactory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage("'index' must not be empty");
@@ -69,7 +69,7 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongHosts() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory sinkFactory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
@@ -80,7 +80,7 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongFlushSize() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory sinkFactory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
@@ -99,7 +99,7 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongRetries() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory sinkFactory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage("'sink.bulk-flush.backoff.max-retries' must be at least 1. Got: 0");
@@ -118,7 +118,7 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongMaxActions() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory sinkFactory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage("'sink.bulk-flush.max-actions' must be at least 1. Got: -2");
@@ -136,7 +136,7 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongBackoffDelay() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory sinkFactory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage("Invalid value for option 'sink.bulk-flush.backoff.delay'.");
@@ -154,7 +154,7 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validatePrimaryKeyOnIllegalColumn() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory sinkFactory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
@@ -216,7 +216,7 @@ public class Elasticsearch7DynamicSinkFactoryTest extends TestLogger {
 
     @Test
     public void validateWrongCredential() {
-        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+        Elasticsearch7DynamicTableFactory sinkFactory = new Elasticsearch7DynamicTableFactory();
 
         thrown.expect(ValidationException.class);
         thrown.expectMessage(

--- a/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicTableTestBase.java
+++ b/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicTableTestBase.java
@@ -1,0 +1,168 @@
+package org.apache.flink.streaming.connectors.elasticsearch.table;
+
+import org.apache.flink.connector.elasticsearch.test.DockerImageVersions;
+import org.apache.flink.test.util.AbstractTestBase;
+
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.client.indices.CreateIndexResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.junit.ClassRule;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+
+import static org.apache.flink.table.api.Expressions.row;
+
+public class Elasticsearch7DynamicTableTestBase extends AbstractTestBase {
+
+    @ClassRule
+    public static ElasticsearchContainer elasticsearchContainer =
+            new ElasticsearchContainer(DockerImageName.parse(DockerImageVersions.ELASTICSEARCH_7));
+
+    public final RestHighLevelClient getClient() {
+        return new RestHighLevelClient(
+                RestClient.builder(HttpHost.create(elasticsearchContainer.getHttpHostAddress())));
+    }
+
+    public boolean createIndex(RestHighLevelClient client, String index, String type, String stringType) throws
+            IOException {
+        // create index
+        CreateIndexRequest request = new CreateIndexRequest(index);
+        request.settings(
+                Settings.builder()
+                        .put("index.number_of_shards", 3)
+                        .put("index.number_of_replicas", 0)
+        );
+
+        //set the string field if 'b' to keyword or text
+        /**
+         * 		request.mapping(
+         * 			type,
+         * 			"{\n" +
+         * 				"  \"properties\": {\n" +
+         * 				"    \"b\": {\n" +
+         * 				"      \"type\": \"text\"\n" +
+         * 				"    }\n" +
+         * 				"  }\n" +
+         * 				"}",
+         * 			XContentType.JSON
+         * 		);
+         */
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        {
+            builder.startObject("properties");
+            {
+                builder.startObject("b");
+                {
+                    builder.field("type", stringType);
+                }
+                builder.endObject();
+            }
+            builder.endObject();
+        }
+        builder.endObject();
+        request.mapping(builder);
+        CreateIndexResponse createIndexResponse = client.indices().create(request, RequestOptions.DEFAULT);
+        return createIndexResponse.isAcknowledged();
+    }
+
+    public void insertData(StreamTableEnvironment tEnv, String index, String type) throws ExecutionException, InterruptedException {
+        String sinkTable = "esTable" + Math.abs(new Random().nextInt());
+
+        tEnv.executeSql("CREATE TABLE " + sinkTable + "(" +
+                "a BIGINT NOT NULL,\n" +
+                "b STRING NOT NULL,\n" +
+                "c FLOAT,\n" +
+                "d TINYINT NOT NULL,\n" +
+                "e TIME,\n" +
+                "f DATE,\n" +
+                "g TIMESTAMP NOT NULL,\n" +
+                "h as a + 2,\n" +
+                "PRIMARY KEY (c, d) NOT ENFORCED\n" +
+                ")\n" +
+                "WITH (\n" +
+                String.format("'%s'='%s',\n", "connector", "elasticsearch-7") +
+                String.format("'%s'='%s',\n", ElasticsearchConnectorOptions.INDEX_OPTION.key(), index) +
+                String.format("'%s'='%s',\n", ElasticsearchConnectorOptions.HOSTS_OPTION.key(), "http://127.0.0.1:9200") +
+                String.format("'%s'='%s'\n", ElasticsearchConnectorOptions.FLUSH_ON_CHECKPOINT_OPTION.key(), "false") +
+                ")");
+
+        tEnv.fromValues(
+                row(
+                        1L,
+                        "A B",
+                        12.10f,
+                        (byte) 2,
+                        LocalTime.ofNanoOfDay(12345L * 1_000_000L),
+                        LocalDate.ofEpochDay(12345),
+                        LocalDateTime.parse("2012-12-12T12:12:12")),
+                row(
+                        1L,
+                        "A",
+                        12.11f,
+                        (byte) 2,
+                        LocalTime.ofNanoOfDay(12345L * 1_000_000L),
+                        LocalDate.ofEpochDay(12345),
+                        LocalDateTime.parse("2012-12-12T12:12:12")),
+                row(
+                        1L,
+                        "A",
+                        12.12f,
+                        (byte) 2,
+                        LocalTime.ofNanoOfDay(12345L * 1_000_000L),
+                        LocalDate.ofEpochDay(12345),
+                        LocalDateTime.parse("2012-12-12T12:12:12")),
+                row(
+                        2L,
+                        "B",
+                        12.13f,
+                        (byte) 3,
+                        LocalTime.ofNanoOfDay(12346L * 1_000_000L),
+                        LocalDate.ofEpochDay(12346),
+                        LocalDateTime.parse("2012-12-12T12:12:13")),
+                row(
+                        3L,
+                        "C",
+                        12.14f,
+                        (byte) 4,
+                        LocalTime.ofNanoOfDay(12347L * 1_000_000L),
+                        LocalDate.ofEpochDay(12347),
+                        LocalDateTime.parse("2012-12-12T12:12:14")),
+                row(
+                        4L,
+                        "D",
+                        12.15f,
+                        (byte) 5,
+                        LocalTime.ofNanoOfDay(12348L * 1_000_000L),
+                        LocalDate.ofEpochDay(12348),
+                        LocalDateTime.parse("2012-12-12T12:12:15")),
+                row(
+                        5L,
+                        "E",
+                        12.16f,
+                        (byte) 6,
+                        LocalTime.ofNanoOfDay(12349L * 1_000_000L),
+                        LocalDate.ofEpochDay(12349),
+                        LocalDateTime.parse("2012-12-12T12:12:16"))
+        ).executeInsert(sinkTable)
+                .getJobClient()
+                .get()
+                .getJobExecutionResult()
+                .get();
+    }
+}

--- a/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticsearchSinkITCase.java
+++ b/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticsearchSinkITCase.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.streaming.connectors.elasticsearch7;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
 import org.apache.flink.connector.elasticsearch.test.DockerImageVersions;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticSearchInputFormatBase;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkTestBase;
@@ -28,17 +30,21 @@ import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkTest
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /** IT cases for the {@link ElasticsearchSink}. */
-public class ElasticsearchSinkITCase
+public class ElasticsearchSinkITCase<T>
         extends ElasticsearchSinkTestBase<RestHighLevelClient, HttpHost> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchSinkITCase.class);
@@ -65,6 +71,12 @@ public class ElasticsearchSinkITCase
     }
 
     @Test
+    public void testElasticsearchInputFormat() throws Exception {
+        runElasticsearchSinkTest();
+        runElasticSearchInputFormatTest();
+    }
+
+    @Test
     public void testNullAddresses() {
         runNullAddressesTest();
     }
@@ -82,9 +94,9 @@ public class ElasticsearchSinkITCase
     @Override
     protected ElasticsearchSinkBase<Tuple2<Integer, String>, RestHighLevelClient>
             createElasticsearchSink(
-                    int bulkFlushMaxActions,
-                    List<HttpHost> httpHosts,
-                    ElasticsearchSinkFunction<Tuple2<Integer, String>> elasticsearchSinkFunction) {
+            int bulkFlushMaxActions,
+            List httpHosts,
+            ElasticsearchSinkFunction<Tuple2<Integer, String>> elasticsearchSinkFunction) {
 
         ElasticsearchSink.Builder<Tuple2<Integer, String>> builder =
                 new ElasticsearchSink.Builder<>(httpHosts, elasticsearchSinkFunction);
@@ -92,6 +104,33 @@ public class ElasticsearchSinkITCase
 
         return builder.build();
     }
+
+    protected ElasticSearchInputFormatBase createElasticsearchInputFormat(
+            Map<String, String> userConfig,
+            DeserializationSchema<RestHighLevelClient> deserializationSchema,
+            String[] fieldNames,
+            String index,
+            String type,
+            long scrollTimeout,
+            int scrollMaxSize,
+            QueryBuilder predicate,
+            int limit) throws Exception {
+        List<InetSocketAddress> transports = new ArrayList<>();
+        transports.add(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 9300));
+
+        ElasticSearch7InputFormat builder = new ElasticSearch7InputFormat.Builder()
+                .setDeserializationSchema(deserializationSchema)
+                .setFieldNames(fieldNames)
+                .setIndex(index)
+                .setScrollTimeout(scrollTimeout)
+                .setScrollMaxSize(scrollMaxSize)
+                .setPredicate(predicate)
+                .setLimit(limit)
+                .build();
+        return builder;
+    }
+
+
 
     @Override
     protected ElasticsearchSinkBase<Tuple2<Integer, String>, RestHighLevelClient>

--- a/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticsearchSinkITCase.java
+++ b/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticsearchSinkITCase.java
@@ -45,7 +45,7 @@ import java.util.Map;
 
 /** IT cases for the {@link ElasticsearchSink}. */
 public class ElasticsearchSinkITCase<T>
-        extends ElasticsearchSinkTestBase<RestHighLevelClient, HttpHost> {
+        extends ElasticsearchSinkTestBase<T, RestHighLevelClient, HttpHost> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchSinkITCase.class);
 
@@ -59,6 +59,7 @@ public class ElasticsearchSinkITCase<T>
         return new RestHighLevelClient(
                 RestClient.builder(HttpHost.create(elasticsearchContainer.getHttpHostAddress())));
     }
+
 
     @Test
     public void testElasticsearchSink() throws Exception {
@@ -95,7 +96,7 @@ public class ElasticsearchSinkITCase<T>
     protected ElasticsearchSinkBase<Tuple2<Integer, String>, RestHighLevelClient>
             createElasticsearchSink(
             int bulkFlushMaxActions,
-            List httpHosts,
+            List<HttpHost> httpHosts,
             ElasticsearchSinkFunction<Tuple2<Integer, String>> elasticsearchSinkFunction) {
 
         ElasticsearchSink.Builder<Tuple2<Integer, String>> builder =
@@ -107,7 +108,7 @@ public class ElasticsearchSinkITCase<T>
 
     protected ElasticSearchInputFormatBase createElasticsearchInputFormat(
             Map<String, String> userConfig,
-            DeserializationSchema<RestHighLevelClient> deserializationSchema,
+            DeserializationSchema<T> deserializationSchema,
             String[] fieldNames,
             String index,
             String type,

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@ under the License.
 	<properties>
 		<flink.version>1.17.0</flink.version>
 		<flink.shaded.version>16.1</flink.shaded.version>
+		<scala.binary.version>2.12</scala.binary.version>
 
 		<jackson-bom.version>2.13.4.20221013</jackson-bom.version>
 		<junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION
According to [FLIP-127](https://cwiki.apache.org/confluence/display/FLINK/FLIP-127%3A+Support+Elasticsearch+Source+Connector) to achieve source read function