### PR TITLE
[FLINK-28347][Test infrastructure] Upgrade testcontainers to 1.18.3

### DIFF
--- a/flink-connector-elasticsearch-e2e-tests/pom.xml
+++ b/flink-connector-elasticsearch-e2e-tests/pom.xml
@@ -39,6 +39,19 @@ under the License.
 		<module>flink-connector-elasticsearch7-e2e-tests</module>
     </modules>
 
+	<dependencyManagement>
+		<dependencies>
+			<!-- We pick the version of net.java.dev.jna:jna to satisfy dependency
+				 convergence for org.testcontainers:testcontainers which transitively depends on
+				 two different versions.-->
+			<dependency>
+				<groupId>net.java.dev.jna</groupId>
+				<artifactId>jna</artifactId>
+				<version>5.12.1</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<profiles>
 		<profile>
 			<id>run-end-to-end-tests</id>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,8 @@ under the License.
 		<junit4.version>4.13.2</junit4.version>
 		<junit5.version>5.9.1</junit5.version>
 		<assertj.version>3.23.1</assertj.version>
-		<testcontainers.version>1.17.2</testcontainers.version>
+		<!-- keep net.java.dev.jna:jna in sync with the one from testcontainers -->
+		<testcontainers.version>1.18.0</testcontainers.version>
 		<mockito.version>3.4.6</mockito.version>
 
 		<japicmp.skip>false</japicmp.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,13 @@ under the License.
 
 			<!-- For dependency convergence  -->
 			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>1.22</version>
+			</dependency>
+
+			<!-- For dependency convergence -->
+			<dependency>
 				<groupId>org.objenesis</groupId>
 				<artifactId>objenesis</artifactId>
 				<version>2.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<junit5.version>5.9.1</junit5.version>
 		<assertj.version>3.23.1</assertj.version>
 		<!-- keep net.java.dev.jna:jna in sync with the one from testcontainers -->
-		<testcontainers.version>1.18.0</testcontainers.version>
+		<testcontainers.version>1.18.3</testcontainers.version>
 		<mockito.version>3.4.6</mockito.version>
 
 		<japicmp.skip>false</japicmp.skip>


### PR DESCRIPTION
Commits are taken from https://github.com/apache/flink-connector-elasticsearch/pull/47
rebased and bumped to 1.18.3