### PR TITLE
[FLINK-26088][Connectors/ElasticSearch] Add Elasticsearch 8.0 support

### DIFF
--- a/flink-connector-elasticsearch8/.gitignore
+++ b/flink-connector-elasticsearch8/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/flink-connector-elasticsearch8/pom.xml
+++ b/flink-connector-elasticsearch8/pom.xml
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connector-elasticsearch-parent</artifactId>
+		<version>4.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>flink-connector-elasticsearch8</artifactId>
+	<name>Flink : Connectors : Elasticsearch 8</name>
+
+	<packaging>jar</packaging>
+
+	<!-- Allow users to pass custom connector versions -->
+	<properties>
+		<elasticsearch.version>8.7.1</elasticsearch.version>
+	</properties>
+
+	<dependencies>
+
+		<!-- Core -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java</artifactId>
+			<version>${flink.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${flink.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Table ecosystem -->
+
+		<!-- Projects depending on this project won't depend on flink-table-*. -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge</artifactId>
+			<version>${flink.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Elasticsearch -->
+
+		<dependency>
+			<groupId>org.elasticsearch</groupId>
+			<artifactId>elasticsearch</artifactId>
+			<version>${elasticsearch.version}</version>
+			<!--
+			FLINK-7133: Excluding all org.ow2.asm from elasticsearch dependencies because
+			1. from the POV of client they are optional,
+			2. the version configured by default at the time of writing this comment (1.7.1) depends on asm 4.1
+			   and when it is shaded into elasticsearch-base artifact it conflicts with newer shaded versions of asm
+			   resulting in errors at the runtime when application is executed locally, e.g. from IDE.
+			-->
+			<exclusions>
+				<exclusion>
+					<groupId>org.ow2.asm</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!-- Dependency for Elasticsearch 8.x REST Client -->
+		<dependency>
+			<groupId>co.elastic.clients</groupId>
+			<artifactId>elasticsearch-java</artifactId>
+			<version>${elasticsearch.version}</version>
+		</dependency>
+
+		<!-- We need to include httpcore-nio again in the correct version due to the exclusion above -->
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore-nio</artifactId>
+			<version>4.4.12</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.12.7.1</version>
+		</dependency>
+
+		<!-- Tests -->
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>elasticsearch</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-test-utils</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${flink.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<!-- Elasticsearch table descriptor testing -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${flink.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Elasticsearch table sink factory testing -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-json</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+
+		<!--
+		Including Log4j2 dependencies for tests is required for the
+		embedded Elasticsearch nodes used in tests to run correctly.
+		-->
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- ArchUit test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-architecture-tests-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.carrotsearch.randomizedtesting</groupId>
+			<artifactId>randomizedtesting-runner</artifactId>
+			<version>2.8.0</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+</project>

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/bulk/BulkProcessor.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/bulk/BulkProcessor.java
@@ -1,0 +1,591 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.bulk;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.transport.TransportOptions;
+import co.elastic.clients.util.ObjectBuilder;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+
+/**
+ * Bulk processor which using @ElasticsearchAsyncClient.
+ *
+ * @param <Context>
+ */
+public class BulkProcessor<Context> implements AutoCloseable {
+
+    private static final Log logger = LogFactory.getLog(BulkProcessor.class);
+
+    // Instance counter, to name the flush thread if we create one
+    private static final AtomicInteger idCounter = new AtomicInteger();
+
+    // Configuration
+    private final ElasticsearchAsyncClient client;
+    private final @Nullable BulkRequest globalSettings;
+    private final int maxConcurrentRequests;
+    private final long maxSize;
+    private final int maxOperations;
+    private final @Nullable BulkListener<Context> listener;
+    private final Long flushIntervalMillis;
+
+    private @Nullable ScheduledFuture<?> flushTask;
+    private @Nullable ScheduledExecutorService scheduler;
+
+    // Current state
+    private List<BulkOperation> operations = new ArrayList<>();
+    private List<Context> contexts = null; // Created on demand
+    private long currentSize;
+    private int requestsInFlightCount;
+    private volatile boolean isClosed = false;
+
+    // Synchronization objects
+    private final ReentrantLock lock = new ReentrantLock();
+    private final FnCondition addCondition = new FnCondition(lock, this::isOverTheLimit);
+    private final FnCondition sendRequestCondition = new FnCondition(lock, this::canSendRequest);
+    private final FnCondition closeCondition = new FnCondition(lock, this::closedAndFlushed);
+
+    private static class RequestExecution<Context> {
+        public final long id;
+        public final BulkRequest request;
+        public final List<Context> contexts;
+        public final CompletionStage<BulkResponse> futureResponse;
+
+        RequestExecution(
+                long id,
+                BulkRequest request,
+                List<Context> contexts,
+                CompletionStage<BulkResponse> futureResponse) {
+            this.id = id;
+            this.request = request;
+            this.contexts = contexts;
+            this.futureResponse = futureResponse;
+        }
+    }
+
+    private BulkProcessor(Builder<Context> builder) {
+        int processorId = idCounter.incrementAndGet();
+        this.client = builder.client;
+        this.globalSettings = builder.globalSettings;
+        this.maxConcurrentRequests = builder.maxConcurrentRequests;
+        this.maxSize = builder.bulkSize < 0 ? 1000 : builder.bulkSize;
+        this.maxOperations =
+                builder.bulkOperations < 0 ? 1000 : builder.bulkOperations;
+        this.listener = builder.listener;
+        this.flushIntervalMillis = builder.flushIntervalMillis;
+
+        if (flushIntervalMillis != null) {
+            long flushInterval = flushIntervalMillis;
+
+            // Create a scheduler if needed
+            ScheduledExecutorService scheduler = builder.scheduler;
+            if (scheduler == null) {
+                scheduler =
+                        Executors.newSingleThreadScheduledExecutor(
+                                (r) -> {
+                                    Thread t = Executors.defaultThreadFactory().newThread(r);
+                                    t.setName("bulk-elasticsearch-flusher#" + processorId);
+                                    t.setDaemon(true);
+                                    return t;
+                                });
+
+                // Keep it, we'll have to close it.
+                this.scheduler = scheduler;
+            }
+
+            this.flushTask =
+                    scheduler.scheduleWithFixedDelay(
+                            this::failsafeFlush,
+                            flushInterval,
+                            flushInterval,
+                            TimeUnit.MILLISECONDS);
+        }
+    }
+
+    // ----- Getters
+
+    /** The configured max operations to buffer in a single bulk request. */
+    public int maxOperations() {
+        return this.maxOperations;
+    }
+
+    /**
+     * The configured maximum size in bytes for a bulk request. Operations are added to the request
+     * until adding an operation leads the request to exceed this siz.
+     */
+    public long maxSize() {
+        return this.maxSize;
+    }
+
+    /** The configured maximum number of concurrent request sent to Elasticsearch. */
+    public int maxConcurrentRequests() {
+        return this.maxConcurrentRequests;
+    }
+
+    /** The configured flush period. */
+    public Duration flushInterval() {
+        if (this.flushIntervalMillis != null) {
+            return Duration.ofMillis(flushIntervalMillis);
+        } else {
+            return null;
+        }
+    }
+
+    /** The number of operations that have been buffered, waiting to be sent. */
+    public int pendingOperations() {
+        List<BulkOperation> operations = this.operations;
+        return operations == null ? 0 : operations.size();
+    }
+
+    /** The size in bytes of operations that have been buffered, waiting to be sent. */
+    public long pendingOperationsSize() {
+        return this.currentSize;
+    }
+
+    /** The number of in flight bulk requests. */
+    public int pendingRequests() {
+        return this.requestsInFlightCount;
+    }
+
+    // ----- Statistics
+
+    /**
+     * Statistics: the number of operations that were added to this ingester since it was created.
+     */
+    public long operationsCount() {
+        return this.addCondition.invocations();
+    }
+
+    /**
+     * Statistics: the number of operations that had to wait before being added because the
+     * operation buffer was full and the number of http requests in flight exceeded the configured
+     * maximum number.
+     *
+     * @see Builder#maxConcurrentRequests
+     * @see Builder#maxOperations
+     * @see Builder#maxSize
+     */
+    public long operationContentionsCount() {
+        return this.addCondition.contentions();
+    }
+
+    /**
+     * Statistics: the number of bulk requests that were produced by this ingester since it was
+     * created.
+     */
+    public long requestCount() {
+        return this.sendRequestCondition.invocations();
+    }
+
+    /**
+     * Statistics: the number of bulk requests that could not be sent immediately because the number
+     * of http requests in flight exceeded the configured maximum number.
+     *
+     * @see Builder#maxConcurrentRequests
+     */
+    public long requestContentionsCount() {
+        return this.sendRequestCondition.contentions();
+    }
+
+    // ----- Predicates for the condition variables
+
+    private boolean canSendRequest() {
+        return requestsInFlightCount < maxConcurrentRequests;
+    }
+
+    private boolean isOverTheLimit() {
+        return currentSize < maxSize && operations.size() < maxOperations;
+    }
+
+    private boolean closedAndFlushed() {
+        return isClosed && operations.isEmpty() && requestsInFlightCount == 0;
+    }
+
+    // ----- BulkProcessor logic
+
+    private BulkRequest.Builder newRequest() {
+        BulkRequest.Builder result = new BulkRequest.Builder();
+
+        if (this.globalSettings != null) {
+            BulkRequest settings = this.globalSettings;
+            result.index(settings.index())
+                    .pipeline(settings.pipeline())
+                    .refresh(settings.refresh())
+                    .requireAlias(settings.requireAlias())
+                    .routing(settings.routing())
+                    .sourceExcludes(settings.sourceExcludes())
+                    .sourceIncludes(settings.sourceIncludes())
+                    .source(settings.source())
+                    .timeout(settings.timeout())
+                    .waitForActiveShards(settings.waitForActiveShards());
+        }
+
+        return result;
+    }
+
+    private void failsafeFlush() {
+        try {
+            flush();
+        } catch (Throwable thr) {
+            // Log the error and continue
+            logger.error("Error in background flush", thr);
+        }
+    }
+
+    public void flush() {
+        RequestExecution<Context> exec =
+                sendRequestCondition.whenReadyIf(
+                        () -> {
+                            // May happen on manual and periodic flushes
+                            return !operations.isEmpty();
+                        },
+                        () -> {
+                            // Build the request
+                            BulkRequest request = newRequest().operations(operations).build();
+                            List<Context> requestContexts =
+                                    contexts == null
+                                            ? Collections.nCopies(operations.size(), null)
+                                            : contexts;
+
+                            // Prepare for next round
+                            operations = new ArrayList<>();
+                            contexts = null;
+                            currentSize = 0;
+                            addCondition.signalIfReady();
+
+                            long id = sendRequestCondition.invocations();
+
+                            if (listener != null) {
+                                listener.beforeBulk(id, request, requestContexts);
+                            }
+
+                            CompletionStage<BulkResponse> result = client.bulk(request);
+                            requestsInFlightCount++;
+
+                            if (listener == null) {
+                                // No need to keep the request around, it can be GC'ed
+                                request = null;
+                            }
+
+                            return new RequestExecution<>(id, request, requestContexts, result);
+                        });
+
+        if (exec != null) {
+            // A request was actually sent
+            exec.futureResponse
+                    .handle(
+                            (resp, thr) -> {
+                                sendRequestCondition.signalIfReadyAfter(
+                                        () -> {
+                                            requestsInFlightCount--;
+                                            closeCondition.signalAllIfReady();
+                                        });
+
+                                if (resp != null) {
+                                    // Success
+                                    if (listener != null) {
+                                        listener.afterBulk(
+                                                exec.id, exec.request, exec.contexts, resp);
+                                    }
+                                } else {
+                                    // Failure
+                                    if (listener != null) {
+                                        listener.afterBulk(
+                                                exec.id, exec.request, exec.contexts, thr);
+                                    }
+                                }
+                                return null;
+                            })
+                    .whenComplete(
+                            (a, thr) -> {
+                                if (thr != null) {
+                                    logger.debug("Flush failed " + thr.getMessage());
+                                } else {
+                                    logger.debug("Flush success");
+                                }
+                            });
+        }
+    }
+
+    public void add(BulkOperation operation, Context context) {
+        if (isClosed) {
+            throw new IllegalStateException("BulkProcessor has been closed");
+        }
+
+        InternalOperation ingestOp = InternalOperation.of(operation, client._jsonpMapper());
+
+        addCondition.whenReady(
+                () -> {
+                    if (context != null) {
+                        // Lazily build the context list
+                        if (contexts == null) {
+                            int size = operations.size();
+                            if (size == 0) {
+                                contexts = new ArrayList<>();
+                            } else {
+                                contexts = new ArrayList<>(Collections.nCopies(size, null));
+                            }
+                        }
+                        contexts.add(context);
+                    }
+                    logger.debug("add operation: " + ingestOp.operation());
+                    operations.add(ingestOp.operation());
+                    currentSize += ingestOp.size();
+
+                    if (!isOverTheLimit()) {
+                        logger.debug("Over the limit and flush now...");
+                        flush();
+                    }
+                });
+    }
+
+    public void add(BulkOperation operation) {
+        add(operation, null);
+    }
+
+    public void add(Function<BulkOperation.Builder, ObjectBuilder<BulkOperation>> f) {
+        add(f.apply(new BulkOperation.Builder()).build(), null);
+    }
+
+    public void add(
+            Function<BulkOperation.Builder, ObjectBuilder<BulkOperation>> f, Context context) {
+        add(f.apply(new BulkOperation.Builder()).build(), context);
+    }
+
+    @Override
+    public void close() {
+        if (isClosed) {
+            return;
+        }
+
+        isClosed = true;
+        // Flush buffered operations
+        flush();
+        // and wait for all requests to be completed
+        closeCondition.whenReady(() -> {});
+
+        if (flushTask != null) {
+            flushTask.cancel(false);
+        }
+
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+
+    public static <Context> BulkProcessor<Context> of(
+            Function<Builder<Context>, Builder<Context>> f) {
+        return f.apply(new Builder<>()).build();
+    }
+
+    public static <Context> BulkProcessor.Builder<Context> ofBuilder(
+            Function<Builder<Context>, Builder<Context>> f) {
+        return f.apply(new Builder<>());
+    }
+
+    /**
+     * Builder.
+     *
+     * @param <Context>
+     */
+    public static class Builder<Context> implements ObjectBuilder<BulkProcessor<Context>> {
+        private ElasticsearchAsyncClient client;
+        private BulkRequest globalSettings;
+        private int bulkOperations = 1000;
+        private long bulkSize = 5 * 1024 * 1024;
+        private int maxConcurrentRequests = 1;
+        private Long flushIntervalMillis = null;
+        private BulkListener<Context> listener;
+        private ScheduledExecutorService scheduler;
+
+        public Builder<Context> client(ElasticsearchAsyncClient client) {
+            this.client = client;
+            return this;
+        }
+
+        public Builder<Context> client(ElasticsearchClient client) {
+            TransportOptions options = client._transportOptions();
+            if (options == client._transport().options()) {
+                options = null;
+            }
+            return client(new ElasticsearchAsyncClient(client._transport(), options));
+        }
+
+        /**
+         * Sets when to flush a new bulk request based on the number of operations currently added.
+         * Defaults to {@code 1000}. Can be set to {@code -1} to disable it.
+         */
+        public Builder<Context> maxOperations(int count) {
+            this.bulkOperations = count;
+            return this;
+        }
+
+        /**
+         * Sets when to flush a new bulk request based on the size in bytes of actions currently
+         * added. A request is sent once that size has been exceeded. Defaults to 5 megabytes. Can
+         * be set to {@code -1} to disable it.
+         */
+        public Builder<Context> maxSize(long bytes) {
+            this.bulkSize = bytes;
+            return this;
+        }
+
+        /**
+         * Sets the number of concurrent requests allowed to be executed. A value of 1 means 1
+         * concurrent request is allowed to be executed while accumulating new bulk requests.
+         * Defaults to {@code 1}.
+         */
+        public Builder<Context> maxConcurrentRequests(int max) {
+            this.maxConcurrentRequests = max;
+            return this;
+        }
+
+        /**
+         * Sets an interval flushing any bulk actions pending if the interval passes. Defaults to
+         * not set.
+         *
+         * <p>Flushing is still subject to the maximum number of requests set with {@link
+         * #maxConcurrentRequests}.
+         */
+        public Builder<Context> flushInterval(long value, TimeUnit unit) {
+            if (value > 0) {
+                this.flushIntervalMillis = unit.toMillis(value);
+            }
+            return this;
+        }
+
+        /**
+         * Sets an interval flushing any bulk actions pending if the interval passes. Defaults to
+         * not set.
+         *
+         * <p>Flushing is still subject to the maximum number of requests set with {@link
+         * #maxConcurrentRequests}.
+         */
+        public Builder<Context> flushInterval(
+                long value, TimeUnit unit, ScheduledExecutorService scheduler) {
+            this.scheduler = scheduler;
+            return flushInterval(value, unit);
+        }
+
+        public Builder<Context> listener(BulkListener<Context> listener) {
+            this.listener = listener;
+            return this;
+        }
+
+        /**
+         * Sets global bulk request settings that will be applied to all requests sent by the
+         * ingester.
+         */
+        public Builder<Context> globalSettings(BulkRequest.Builder settings) {
+            if (settings != null) {
+                // Set required field
+                this.globalSettings = settings.operations(Collections.emptyList()).build();
+            } else {
+                this.globalSettings = null;
+            }
+            return this;
+        }
+
+        /** Sets global bulk request settings that will be applied to all bulk requests. */
+        public Builder<Context> globalSettings(
+                Function<BulkRequest.Builder, BulkRequest.Builder> fn) {
+            return globalSettings(fn.apply(new BulkRequest.Builder()));
+        }
+
+        @Override
+        public BulkProcessor<Context> build() {
+            return new BulkProcessor<>(this);
+        }
+    }
+
+    /**
+     * A listener that is called by a {@link BulkProcessor} to allow monitoring requests sent and
+     * their result.
+     *
+     * @param <Context> application-defined contextual data that can be associated to a bulk
+     *     operation.
+     */
+    public interface BulkListener<Context> extends Serializable {
+
+        /**
+         * Called before a bulk request is sent. <b>Note:</b> documents in {@code request}
+         * operations have been converted to {@link co.elastic.clients.util.BinaryData}.
+         *
+         * @param executionId the id of this request, unique for the {@link BulkProcessor} that
+         *     created it.
+         * @param request the bulk request that will be sent, with documents in binary form.
+         * @param contexts application-defined data that was passed in {@link
+         *     BulkProcessor#add(BulkOperation, Object)}.
+         */
+        void beforeBulk(long executionId, BulkRequest request, List<Context> contexts);
+
+        /**
+         * Called after a bulk request has been processed. Elasticsearch accepted the request, but
+         * {@code response} the response may contain both successful and failure response items.
+         *
+         * @param executionId the id of this request, unique for the {@link BulkProcessor} that
+         *     created it.
+         * @param request the bulk request that will be sent, with documents in binary form.
+         * @param contexts application-defined data that was passed in {@link
+         *     BulkProcessor#add(BulkOperation, Object)}.
+         * @param response the response received from Elasticsearch.
+         */
+        void afterBulk(
+                long executionId,
+                BulkRequest request,
+                List<Context> contexts,
+                BulkResponse response);
+
+        /**
+         * Called when a bulk request could not be sent to Elasticsearch.
+         *
+         * @param executionId the id of this request, unique for the {@link BulkProcessor} that
+         *     created it.
+         * @param request the bulk request that will be sent, with documents in binary form.
+         * @param contexts application-defined data that was passed in {@link
+         *     BulkProcessor#add(BulkOperation, Object)}.
+         * @param failure the failure that occurred when sending the request to Elasticsearch.
+         */
+        void afterBulk(
+                long executionId, BulkRequest request, List<Context> contexts, Throwable failure);
+    }
+}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/bulk/FnCondition.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/bulk/FnCondition.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.bulk;
+
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+/**
+ * A helper to make {@link Condition} easier and less error-prone to use.
+ *
+ * <p>It takes a {@code Lock} and a readiness predicate.
+ */
+class FnCondition {
+    private final Lock lock;
+    public final Condition condition;
+    private final BooleanSupplier ready;
+    private long invocations;
+    private long contentions;
+
+    FnCondition(Lock lock, BooleanSupplier ready) {
+        this.lock = lock;
+        this.condition = lock.newCondition();
+        this.ready = ready;
+    }
+
+    public void whenReady(Runnable fn) {
+        whenReadyIf(
+                null,
+                () -> {
+                    fn.run();
+                    return null;
+                });
+    }
+
+    /** Runs a function when the condition variable is ready. */
+    public <T> T whenReady(Supplier<T> fn) {
+        return whenReadyIf(null, fn);
+    }
+
+    /**
+     * Runs a function when the condition variable is ready, after verifying in that it can actually
+     * run.
+     *
+     * <p>{@code canRun} and {@code fn} are executed withing the lock.
+     *
+     * @param canRun a predicate indicating if {@code fn} is ready to run. If not, returns {@code
+     *     null} immediately.
+     * @param fn the function to run once the condition variable allows it.
+     * @return the result of {@code fn}.
+     */
+    public <T> T whenReadyIf(BooleanSupplier canRun, Supplier<T> fn) {
+        lock.lock();
+        try {
+            if (canRun != null && !canRun.getAsBoolean()) {
+                return null;
+            }
+
+            invocations++;
+            boolean firstLoop = true;
+            while (!ready.getAsBoolean()) {
+                if (firstLoop) {
+                    contentions++;
+                    firstLoop = false;
+                }
+                condition.awaitUninterruptibly();
+            }
+
+            if (canRun != null && !canRun.getAsBoolean()) {
+                return null;
+            }
+
+            return fn.get();
+        } catch (Throwable e) {
+            e.printStackTrace();
+            return null;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void signalIfReady() {
+        lock.lock();
+        try {
+            if (ready.getAsBoolean()) {
+                this.condition.signal();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void signalAllIfReady() {
+        lock.lock();
+        try {
+            if (ready.getAsBoolean()) {
+                this.condition.signalAll();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void signalIfReadyAfter(Runnable r) {
+        lock.lock();
+        try {
+            r.run();
+            if (ready.getAsBoolean()) {
+                this.condition.signal();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Number of invocations of {@code whenReady}. */
+    public long invocations() {
+        return this.invocations;
+    }
+
+    /**
+     * Number of invocations of {@code whenReady} that contended and required to wait on the
+     * condition variable.
+     */
+    public long contentions() {
+        return this.contentions;
+    }
+}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/bulk/InternalOperation.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/bulk/InternalOperation.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.bulk;
+
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperationBase;
+import co.elastic.clients.elasticsearch.core.bulk.CreateOperation;
+import co.elastic.clients.elasticsearch.core.bulk.DeleteOperation;
+import co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
+import co.elastic.clients.elasticsearch.core.bulk.UpdateOperation;
+import co.elastic.clients.json.JsonEnum;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.util.BinaryData;
+
+import javax.annotation.Nullable;
+
+/**
+ * A bulk operation whose size has been calculated and content turned to a binary blob (to compute
+ * its size).
+ */
+public class InternalOperation {
+    private final BulkOperation operation;
+    private final long size;
+
+    public InternalOperation(BulkOperation operation, long size) {
+        this.operation = operation;
+        this.size = size;
+    }
+
+    public static InternalOperation of(BulkOperation operation, JsonpMapper mapper) {
+        switch (operation._kind()) {
+            case Create:
+                return createOperation(operation, mapper);
+            case Index:
+                return indexOperation(operation, mapper);
+            case Update:
+                return updateOperation(operation, mapper);
+            case Delete:
+                return deleteOperation(operation);
+            default:
+                throw new IllegalStateException("Unknown bulk operation type " + operation._kind());
+        }
+    }
+
+    public BulkOperation operation() {
+        return this.operation;
+    }
+
+    public long size() {
+        return this.size;
+    }
+
+    private static InternalOperation createOperation(BulkOperation operation, JsonpMapper mapper) {
+        CreateOperation<?> create = operation.create();
+        BulkOperation newOperation;
+
+        long size = basePropertiesSize(create);
+
+        if (create.document() instanceof BinaryData) {
+            newOperation = operation;
+            size += ((BinaryData) create.document()).size();
+
+        } else {
+            BinaryData binaryDoc = BinaryData.of(create.document(), mapper);
+            size += binaryDoc.size();
+            newOperation =
+                    BulkOperation.of(
+                            bo ->
+                                    bo.create(
+                                            idx -> {
+                                                copyBaseProperties(create, idx);
+                                                return idx.document(binaryDoc);
+                                            }));
+        }
+
+        return new InternalOperation(newOperation, size);
+    }
+
+    private static InternalOperation indexOperation(BulkOperation operation, JsonpMapper mapper) {
+        IndexOperation<?> index = operation.index();
+        BulkOperation newOperation;
+
+        long size = basePropertiesSize(index);
+
+        if (index.document() instanceof BinaryData) {
+            newOperation = operation;
+            size += ((BinaryData) index.document()).size();
+
+        } else {
+            BinaryData binaryDoc = BinaryData.of(index.document(), mapper);
+            size += binaryDoc.size();
+            newOperation =
+                    BulkOperation.of(
+                            bo ->
+                                    bo.index(
+                                            idx -> {
+                                                copyBaseProperties(index, idx);
+                                                return idx.document(binaryDoc);
+                                            }));
+        }
+
+        return new InternalOperation(newOperation, size);
+    }
+
+    private static InternalOperation updateOperation(BulkOperation operation, JsonpMapper mapper) {
+        UpdateOperation<?, ?> update = operation.update();
+        BulkOperation newOperation;
+
+        long size =
+                basePropertiesSize(update)
+                        + size("retry_on_conflict", update.retryOnConflict())
+                        + size("require_alias", update.requireAlias());
+
+        if (update.binaryAction() != null) {
+            newOperation = operation;
+            size += update.binaryAction().size();
+
+        } else {
+            BinaryData action = BinaryData.of(update.action(), mapper);
+            size += action.size();
+            newOperation =
+                    BulkOperation.of(
+                            bo ->
+                                    bo.update(
+                                            u -> {
+                                                copyBaseProperties(update, u);
+                                                return u.binaryAction(action)
+                                                        .requireAlias(update.requireAlias())
+                                                        .retryOnConflict(update.retryOnConflict());
+                                            }));
+        }
+
+        return new InternalOperation(newOperation, size);
+    }
+
+    private static InternalOperation deleteOperation(BulkOperation operation) {
+        DeleteOperation delete = operation.delete();
+        return new InternalOperation(operation, basePropertiesSize(delete));
+    }
+
+    private static void copyBaseProperties(
+            BulkOperationBase op, BulkOperationBase.AbstractBuilder<?> builder) {
+        builder.id(op.id())
+                .index(op.index())
+                .ifPrimaryTerm(op.ifPrimaryTerm())
+                .ifSeqNo(op.ifSeqNo())
+                .routing(op.routing())
+                .version(op.version())
+                .versionType(op.versionType());
+    }
+
+    private static int size(String name, @Nullable Boolean value) {
+        if (value != null) {
+            return name.length() + 12; // 12 added chars for "name":"false",
+        } else {
+            return 0;
+        }
+    }
+
+    private static int size(String name, @Nullable String value) {
+        if (value != null) {
+            return name.length() + value.length() + 6; // 6 added chars for "name":"value",
+        } else {
+            return 0;
+        }
+    }
+
+    private static int size(String name, @Nullable Long value) {
+        if (value != null) {
+            // Borrowed from Long.toUnsignedString0, shift = 3 (base 10 is closer to 3 than 4)
+            int mag = Integer.SIZE - Long.numberOfLeadingZeros(value);
+            int chars = Math.max(((mag + (3 - 1)) / 3), 1);
+            return name.length() + chars + 4; // 4 added chars for "name":,
+        } else {
+            return 0;
+        }
+    }
+
+    private static int size(String name, @Nullable Integer value) {
+        if (value != null) {
+            // Borrowed from Integer.toUnsignedString0, shift = 3 (base 10 is closer to 3 than 4)
+            int mag = Integer.SIZE - Integer.numberOfLeadingZeros(value);
+            int chars = Math.max(((mag + (3 - 1)) / 3), 1);
+            return name.length() + chars + 4;
+        } else {
+            return 0;
+        }
+    }
+
+    private static int size(String name, @Nullable JsonEnum value) {
+        if (value != null) {
+            return name.length() + value.jsonValue().length() + 6;
+        } else {
+            return 0;
+        }
+    }
+
+    private static int basePropertiesSize(BulkOperationBase op) {
+        return size("id", op.id())
+                + size("index", op.index())
+                + size("if_primary_term", op.ifPrimaryTerm())
+                + size("if_seq_no", op.ifSeqNo())
+                + size("routing", op.routing())
+                + size("version", op.version())
+                + size("version_type", op.versionType())
+                + 4; // Open/closing brace, 2 newlines
+    }
+}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/bulk/RequestIndexer.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/bulk/RequestIndexer.java
@@ -1,0 +1,21 @@
+package org.apache.flink.connector.elasticsearch.bulk;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+
+/**
+ * Users add multiple delete, index or update requests to a {@link
+ * org.apache.flink.connector.elasticsearch.bulk.RequestIndexer} to prepare them for sending to an
+ * Elasticsearch cluster.
+ */
+@PublicEvolving
+public interface RequestIndexer {
+    /**
+     * Add multiple {@link BulkOperation} to the indexer to prepare for sending requests to
+     * Elasticsearch.
+     *
+     * @param operations The multiple {@link BulkOperation} to add.
+     */
+    void add(BulkOperation... operations);
+}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/BulkProcessorConfig.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/BulkProcessorConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+class BulkProcessorConfig implements Serializable {
+
+    private final int bulkFlushMaxActions;
+    private final int bulkFlushMaxMb;
+    private final long bulkFlushInterval;
+    private final FlushBackoffType flushBackoffType;
+    private final int bulkFlushBackoffRetries;
+    private final long bulkFlushBackOffDelay;
+
+    BulkProcessorConfig(
+            int bulkFlushMaxActions,
+            int bulkFlushMaxMb,
+            long bulkFlushInterval,
+            FlushBackoffType flushBackoffType,
+            int bulkFlushBackoffRetries,
+            long bulkFlushBackOffDelay) {
+        this.bulkFlushMaxActions = bulkFlushMaxActions;
+        this.bulkFlushMaxMb = bulkFlushMaxMb;
+        this.bulkFlushInterval = bulkFlushInterval;
+        this.flushBackoffType = checkNotNull(flushBackoffType);
+        this.bulkFlushBackoffRetries = bulkFlushBackoffRetries;
+        this.bulkFlushBackOffDelay = bulkFlushBackOffDelay;
+    }
+
+    public int getBulkFlushMaxActions() {
+        return bulkFlushMaxActions;
+    }
+
+    public int getBulkFlushMaxMb() {
+        return bulkFlushMaxMb;
+    }
+
+    public long getBulkFlushInterval() {
+        return bulkFlushInterval;
+    }
+
+    public FlushBackoffType getFlushBackoffType() {
+        return flushBackoffType;
+    }
+
+    public int getBulkFlushBackoffRetries() {
+        return bulkFlushBackoffRetries;
+    }
+
+    public long getBulkFlushBackOffDelay() {
+        return bulkFlushBackOffDelay;
+    }
+}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/BulkProcessorFactory.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/BulkProcessorFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.elasticsearch.bulk.BulkProcessor;
+import org.apache.flink.util.function.TriFunction;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+
+import java.io.Serializable;
+
+@Internal
+interface BulkProcessorFactory<Context>
+        extends Serializable,
+                TriFunction<
+                        ElasticsearchClient,
+                        BulkProcessorConfig,
+                        BulkProcessor.BulkListener<Context>,
+                        BulkProcessor.Builder<Context>> {}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8Emitter.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8Emitter.java
@@ -1,0 +1,61 @@
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.elasticsearch.bulk.RequestIndexer;
+
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+
+/**
+ * Creates none or multiple {@link BulkOperation BulkOperation} from the incoming elements.
+ *
+ * <p>This is used by sinks to prepare elements for sending them to Elasticsearch.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * private static class TestElasticsearchEmitter implements ElasticsearchEmitter<Tuple2<Integer, String>> {
+ *
+ *     public IndexRequest createIndexRequest(Tuple2<Integer, String> element) {
+ *         Map<String, Object> document = new HashMap<>();
+ * 		   document.put("data", element.f1);
+ *
+ * 	       return Requests.indexRequest()
+ * 		       .index("my-index")
+ * 			   .type("my-type")
+ * 			   .id(element.f0.toString())
+ * 			   .source(document);
+ *     }
+ *
+ * 	   public void emit(Tuple2<Integer, String> element, RequestIndexer indexer) {
+ * 	       indexer.add(createIndexRequest(element));
+ *     }
+ * }
+ *
+ * }</pre>
+ *
+ * @param <T> The type of the element handled by this {@link Elasticsearch8Emitter}
+ */
+@PublicEvolving
+public interface Elasticsearch8Emitter<T> extends Function {
+
+    /**
+     * Initialization method for the function. It is called once before the actual working process
+     * methods.
+     */
+    default void open() throws Exception {}
+
+    /** Tear-down method for the function. It is called when the sink closes. */
+    default void close() throws Exception {}
+
+    /**
+     * Process the incoming element to produce multiple {@link BulkOperation BulkOperation}. The
+     * produced requests should be added to the provided {@link RequestIndexer}.
+     *
+     * @param element incoming element to process
+     * @param context to access additional information about the record
+     * @param indexer request indexer that {@code ActionRequest} should be added to
+     */
+    void emit(T element, SinkWriter.Context context, RequestIndexer indexer);
+}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8Sink.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8Sink.java
@@ -1,0 +1,85 @@
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+
+import org.apache.http.HttpHost;
+
+import javax.net.ssl.SSLContext;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Flink Sink to insert or update data in an Elasticsearch index. The sink supports the following
+ * delivery guarantees.
+ *
+ * <ul>
+ *   <li>{@link DeliveryGuarantee#NONE} does not provide any guarantees: actions are flushed to
+ *       Elasticsearch only depending on the configurations of the bulk processor. In case of a
+ *       failure, it might happen that actions are lost if the bulk processor still has buffered
+ *       actions.
+ *   <li>{@link DeliveryGuarantee#AT_LEAST_ONCE} on a checkpoint the sink will wait until all
+ *       buffered actions are flushed to and acknowledged by Elasticsearch. No actions will be lost
+ *       but actions might be sent to Elasticsearch multiple times when Flink restarts. These
+ *       additional requests may cause inconsistent data in ElasticSearch right after the restart,
+ *       but eventually everything will be consistent again.
+ * </ul>
+ *
+ * @param <IN> type of the records converted to Elasticsearch actions
+ * @see Elasticsearch8SinkBuilderBase on how to construct a ElasticsearchSink
+ */
+@PublicEvolving
+public class Elasticsearch8Sink<IN> implements Sink<IN> {
+
+    private final List<HttpHost> hosts;
+    private final SSLContext sslContext;
+    private final Elasticsearch8Emitter<? super IN> emitter;
+    private final BulkProcessorConfig buildBulkProcessorConfig;
+    private final BulkProcessorFactory<IN> bulkProcessorFactory;
+    private final NetworkClientConfig networkClientConfig;
+    private final DeliveryGuarantee deliveryGuarantee;
+
+    Elasticsearch8Sink(
+            List<HttpHost> hosts,
+            SSLContext sslContext,
+            Elasticsearch8Emitter<? super IN> emitter,
+            DeliveryGuarantee deliveryGuarantee,
+            BulkProcessorFactory<IN> bulkProcessorFactory,
+            BulkProcessorConfig buildBulkProcessorConfig,
+            NetworkClientConfig networkClientConfig) {
+        this.hosts = checkNotNull(hosts);
+        this.sslContext = sslContext;
+        this.bulkProcessorFactory = checkNotNull(bulkProcessorFactory);
+        checkArgument(!hosts.isEmpty(), "Hosts cannot be empty.");
+        this.emitter = checkNotNull(emitter);
+        this.deliveryGuarantee = checkNotNull(deliveryGuarantee);
+        this.buildBulkProcessorConfig = checkNotNull(buildBulkProcessorConfig);
+        this.networkClientConfig = checkNotNull(networkClientConfig);
+    }
+
+    @Override
+    public SinkWriter<IN> createWriter(InitContext context) throws IOException {
+        return new Elasticsearch8Writer<IN>(
+                hosts,
+                sslContext,
+                emitter,
+                deliveryGuarantee == DeliveryGuarantee.AT_LEAST_ONCE,
+                buildBulkProcessorConfig,
+                bulkProcessorFactory,
+                networkClientConfig,
+                context.metricGroup(),
+                context.getMailboxExecutor());
+    }
+
+    @VisibleForTesting
+    DeliveryGuarantee getDeliveryGuarantee() {
+        return deliveryGuarantee;
+    }
+}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8SinkBuilder.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8SinkBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.elasticsearch.bulk.BulkProcessor;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Builder to construct an Elasticsearch 8 compatible {@link Elasticsearch8Sink}.
+ *
+ * <p>The following example shows the minimal setup to create a ElasticsearchSink that submits
+ * actions on checkpoint or the default number of actions was buffered (1000).
+ *
+ * <pre>{@code
+ * ElasticsearchSink<String> sink = new Elasticsearch8SinkBuilder<String>()
+ *     .setHosts(new HttpHost("localhost:9200")
+ *     .setEmitter((element, context, indexer) -> {
+ *          indexer.add(
+ *              new IndexRequest("my-index")
+ *              .id(element.f0.toString())
+ *              .source(element.f1)
+ *          );
+ *      })
+ *     .build();
+ * }</pre>
+ *
+ * @param <IN> type of the records converted to Elasticsearch actions
+ */
+@PublicEvolving
+public class Elasticsearch8SinkBuilder<IN>
+        extends Elasticsearch8SinkBuilderBase<IN, Elasticsearch8SinkBuilder<IN>> {
+
+    public Elasticsearch8SinkBuilder() {}
+
+    @Override
+    public <T extends IN> Elasticsearch8SinkBuilder<T> setEmitter(
+            Elasticsearch8Emitter<? super T> emitter) {
+        super.<T>setEmitter(emitter);
+        return self();
+    }
+
+    @Override
+    protected BulkProcessorFactory<IN> getBulkProcessorBuilderFactory() {
+        return new BulkProcessorFactory<IN>() {
+            @Override
+            public BulkProcessor.Builder<IN> apply(
+                    ElasticsearchClient client,
+                    BulkProcessorConfig bulkProcessorConfig,
+                    BulkProcessor.BulkListener<IN> listener) {
+                int maxOperations =
+                        (bulkProcessorConfig.getBulkFlushMaxActions() != -1)
+                                ? bulkProcessorConfig.getBulkFlushMaxActions()
+                                : 1;
+                long flushInterval = bulkProcessorConfig.getBulkFlushInterval();
+                int maxSize =
+                        (bulkProcessorConfig.getBulkFlushMaxMb() != -1)
+                                ? bulkProcessorConfig.getBulkFlushMaxMb()
+                                : 1;
+                BulkProcessor.Builder<IN> builder =
+                        BulkProcessor.ofBuilder(
+                                b ->
+                                        b.client(client)
+                                                .listener(listener)
+                                                .maxOperations(maxOperations)
+                                                .maxSize(maxSize)
+                                                .flushInterval(
+                                                        flushInterval, TimeUnit.MILLISECONDS));
+                return builder;
+            }
+        };
+    }
+}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8SinkBuilderBase.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8SinkBuilderBase.java
@@ -1,0 +1,207 @@
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.java.ClosureCleaner;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.http.HttpHost;
+
+import javax.net.ssl.SSLContext;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Base builder to construct a {@link Elasticsearch8Sink}.
+ *
+ * @param <IN> type of the records converted to Elasticsearch actions
+ */
+@PublicEvolving
+public abstract class Elasticsearch8SinkBuilderBase
+        <IN, B extends Elasticsearch8SinkBuilderBase<IN, B>> {
+
+    private int bulkFlushMaxActions = 1000;
+    private int bulkFlushMaxMb = -1;
+    private long bulkFlushInterval = -1;
+    private FlushBackoffType bulkFlushBackoffType = FlushBackoffType.NONE;
+    private int bulkFlushBackoffRetries = -1;
+    private long bulkFlushBackOffDelay = -1;
+    private DeliveryGuarantee deliveryGuarantee = DeliveryGuarantee.AT_LEAST_ONCE;
+    private List<HttpHost> hosts;
+    private SSLContext sslContext;
+    private Elasticsearch8Emitter<? super IN> emitter;
+    private String username;
+    private String password;
+    private String connectionPathPrefix;
+    private Integer connectionTimeout;
+    private Integer connectionRequestTimeout;
+    private Integer socketTimeout;
+
+    protected Elasticsearch8SinkBuilderBase() {}
+
+    @SuppressWarnings("unchecked")
+    protected <S extends Elasticsearch8SinkBuilderBase<?, ?>> S self() {
+        return (S) this;
+    }
+
+    public <T extends IN> Elasticsearch8SinkBuilderBase<T, ?> setEmitter(
+            Elasticsearch8Emitter<? super T> emitter) {
+        checkNotNull(emitter);
+        checkState(
+                InstantiationUtil.isSerializable(emitter),
+                "The elasticsearch emitter must be serializable.");
+
+        final Elasticsearch8SinkBuilderBase<T, ?> self = self();
+        self.emitter = emitter;
+        return self;
+    }
+
+    public B setHosts(HttpHost... hosts) {
+        checkNotNull(hosts);
+        checkState(hosts.length > 0, "Hosts cannot be empty.");
+        this.hosts = Arrays.asList(hosts);
+        return self();
+    }
+
+    public B setSSLContext(SSLContext sslContext) {
+        this.sslContext = sslContext;
+        return self();
+    }
+
+    public B setDeliveryGuarantee(DeliveryGuarantee deliveryGuarantee) {
+        checkState(
+                deliveryGuarantee != DeliveryGuarantee.EXACTLY_ONCE,
+                "Elasticsearch sink does not support the EXACTLY_ONCE guarantee.");
+        this.deliveryGuarantee = checkNotNull(deliveryGuarantee);
+        return self();
+    }
+
+    public B setBulkFlushMaxActions(int numMaxActions) {
+        checkState(
+                numMaxActions == -1 || numMaxActions > 0,
+                "Max number of buffered actions must be larger than 0.");
+        this.bulkFlushMaxActions = numMaxActions;
+        return self();
+    }
+
+    public B setBulkFlushMaxSizeMb(int maxSizeMb) {
+        checkState(
+                maxSizeMb == -1 || maxSizeMb > 0,
+                "Max size of buffered actions must be larger than 0.");
+        this.bulkFlushMaxMb = maxSizeMb;
+        return self();
+    }
+
+    public B setBulkFlushInterval(long intervalMillis) {
+        checkState(
+                intervalMillis == -1 || intervalMillis >= 0,
+                "Interval (in milliseconds) between each flush must be larger than "
+                        + "or equal to 0.");
+        this.bulkFlushInterval = intervalMillis;
+        return self();
+    }
+
+    public B setBulkFlushBackoffStrategy(
+            FlushBackoffType flushBackoffType, int maxRetries, long delayMillis) {
+        this.bulkFlushBackoffType = checkNotNull(flushBackoffType);
+        checkState(
+                flushBackoffType != FlushBackoffType.NONE,
+                "FlushBackoffType#NONE does not require a configuration it is the default, retries and delay are ignored.");
+        checkState(maxRetries > 0, "Max number of backoff attempts must be larger than 0.");
+        this.bulkFlushBackoffRetries = maxRetries;
+        checkState(
+                delayMillis >= 0,
+                "Delay (in milliseconds) between each backoff attempt must be larger "
+                        + "than or equal to 0.");
+        this.bulkFlushBackOffDelay = delayMillis;
+        return self();
+    }
+
+    public B setConnectionUsername(String username) {
+        checkNotNull(username);
+        this.username = username;
+        return self();
+    }
+
+    public B setConnectionPassword(String password) {
+        checkNotNull(password);
+        this.password = password;
+        return self();
+    }
+
+    public B setConnectionPathPrefix(String prefix) {
+        checkNotNull(prefix);
+        this.connectionPathPrefix = prefix;
+        return self();
+    }
+
+    public B setConnectionRequestTimeout(int timeout) {
+        checkState(timeout >= 0, "Connection request timeout must be larger than or equal to 0.");
+        this.connectionRequestTimeout = timeout;
+        return self();
+    }
+
+    public B setConnectionTimeout(int timeout) {
+        checkState(timeout >= 0, "Connection timeout must be larger than or equal to 0.");
+        this.connectionTimeout = timeout;
+        return self();
+    }
+
+    public B setSocketTimeout(int timeout) {
+        checkState(timeout >= 0, "Socket timeout must be larger than or equal to 0.");
+        this.socketTimeout = timeout;
+        return self();
+    }
+
+    protected abstract BulkProcessorFactory<IN> getBulkProcessorBuilderFactory();
+
+    public Elasticsearch8Sink<IN> build() {
+        checkNotNull(emitter);
+        checkNotNull(hosts);
+
+        NetworkClientConfig networkClientConfig = buildNetworkClientConfig();
+        BulkProcessorConfig bulkProcessorConfig = buildBulkProcessorConfig();
+
+        BulkProcessorFactory<IN> bulkProcessorFactory = getBulkProcessorBuilderFactory();
+        ClosureCleaner.clean(
+                bulkProcessorFactory, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
+
+        return new Elasticsearch8Sink<>(
+                hosts,
+                sslContext,
+                emitter,
+                deliveryGuarantee,
+                bulkProcessorFactory,
+                bulkProcessorConfig,
+                networkClientConfig);
+    }
+
+    private NetworkClientConfig buildNetworkClientConfig() {
+        checkArgument(!hosts.isEmpty(), "Hosts cannot be empty.");
+
+        return new NetworkClientConfig(
+                username,
+                password,
+                connectionPathPrefix,
+                connectionRequestTimeout,
+                connectionTimeout,
+                socketTimeout);
+    }
+
+    private BulkProcessorConfig buildBulkProcessorConfig() {
+        return new BulkProcessorConfig(
+                bulkFlushMaxActions,
+                bulkFlushMaxMb,
+                bulkFlushInterval,
+                bulkFlushBackoffType,
+                bulkFlushBackoffRetries,
+                bulkFlushBackOffDelay);
+    }
+
+}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8Writer.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8Writer.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.elasticsearch.bulk.BulkProcessor;
+import org.apache.flink.connector.elasticsearch.bulk.RequestIndexer;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ErrorCause;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+class Elasticsearch8Writer<IN> implements SinkWriter<IN> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Elasticsearch8Writer.class);
+
+    private final SSLContext sslContext;
+    private final Elasticsearch8Emitter<? super IN> emitter;
+    private final MailboxExecutor mailboxExecutor;
+    private final boolean flushOnCheckpoint;
+    private final BulkProcessor<IN> bulkProcessor;
+    private final ElasticsearchClient client;
+    private final RequestIndexer requestIndexer;
+    private final Counter numBytesOutCounter;
+
+    private long pendingActions = 0;
+    private boolean checkpointInProgress = false;
+    private volatile long lastSendTime = 0;
+    private volatile long ackTime = Long.MAX_VALUE;
+    private volatile boolean closed = false;
+
+    public Elasticsearch8Writer(
+            List<HttpHost> hosts,
+            SSLContext sslContext,
+            Elasticsearch8Emitter<? super IN> emitter,
+            boolean flushOnCheckpoint,
+            BulkProcessorConfig bulkProcessorConfig,
+            BulkProcessorFactory<IN> bulkProcessorFactory,
+            NetworkClientConfig networkClientConfig,
+            SinkWriterMetricGroup metricGroup,
+            MailboxExecutor mailboxExecutor)
+            throws IOException {
+        this.sslContext = sslContext == null ? getSSLContext() : sslContext;
+        this.emitter = checkNotNull(emitter);
+        this.flushOnCheckpoint = flushOnCheckpoint;
+        this.mailboxExecutor = checkNotNull(mailboxExecutor);
+        this.client = createClient(hosts, networkClientConfig);
+        this.bulkProcessor = createBulkProcessor(bulkProcessorFactory, bulkProcessorConfig);
+        this.requestIndexer =
+                new Elasticsearch8Writer<IN>.DefaultRequestIndexer(
+                        metricGroup.getNumRecordsSendCounter());
+        checkNotNull(metricGroup);
+        metricGroup.setCurrentSendTimeGauge(() -> ackTime - lastSendTime);
+        this.numBytesOutCounter = metricGroup.getIOMetricGroup().getNumBytesOutCounter();
+        try {
+            emitter.open();
+        } catch (Exception e) {
+            throw new FlinkRuntimeException("Failed to open the ElasticsearchEmitter", e);
+        }
+    }
+
+    @Override
+    public void write(IN element, Context context) throws IOException, InterruptedException {
+        // do not allow new bulk writes until all actions are flushed
+        while (checkpointInProgress) {
+            mailboxExecutor.yield();
+        }
+        emitter.emit(element, context, requestIndexer);
+    }
+
+    @Override
+    public void flush(boolean endOfInput) throws IOException, InterruptedException {
+        checkpointInProgress = true;
+        while (pendingActions != 0 && (flushOnCheckpoint || endOfInput)) {
+            bulkProcessor.flush();
+            LOG.info("Waiting for the response of {} pending actions.", pendingActions);
+            mailboxExecutor.yield();
+        }
+        checkpointInProgress = false;
+    }
+
+    @VisibleForTesting
+    void blockingFlushAllActions() throws InterruptedException {
+        while (pendingActions != 0) {
+            bulkProcessor.flush();
+            LOG.info("Waiting for the response of {} pending actions.", pendingActions);
+            mailboxExecutor.yield();
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        closed = true;
+        emitter.close();
+        bulkProcessor.close();
+        client.shutdown();
+    }
+
+    private static ElasticsearchClient createClient(
+            List<HttpHost> httpHosts, NetworkClientConfig networkClientConfig) throws IOException {
+        String username = networkClientConfig.getUsername();
+        String password = networkClientConfig.getPassword();
+        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        if (StringUtils.isNoneEmpty(username) && StringUtils.isNoneEmpty(password)) {
+            credentialsProvider.setCredentials(
+                    AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+        }
+
+        RestClientBuilder builder =
+                RestClient.builder(httpHosts.toArray(new HttpHost[httpHosts.size()]));
+        RestClientBuilder restClientBuilder =
+                configureRestClientBuilder(builder, networkClientConfig);
+        RestClient httpClient = restClientBuilder.build();
+        ElasticsearchTransport transport =
+                new RestClientTransport(httpClient, new JacksonJsonpMapper());
+        return new ElasticsearchClient(transport);
+    }
+
+    private static RestClientBuilder configureRestClientBuilder(
+            RestClientBuilder builder, NetworkClientConfig networkClientConfig) throws IOException {
+        if (networkClientConfig.getConnectionPathPrefix() != null) {
+            builder.setPathPrefix(networkClientConfig.getConnectionPathPrefix());
+        }
+        if (networkClientConfig.getPassword() != null
+                && networkClientConfig.getUsername() != null) {
+            final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(
+                    AuthScope.ANY,
+                    new UsernamePasswordCredentials(
+                            networkClientConfig.getUsername(), networkClientConfig.getPassword()));
+            SSLContext sslContext = getSSLContext();
+            builder.setHttpClientConfigCallback(
+                    b ->
+                            b.setDefaultCredentialsProvider(credentialsProvider)
+                                    .setSSLContext(sslContext));
+        }
+        if (networkClientConfig.getConnectionRequestTimeout() != null
+                || networkClientConfig.getConnectionTimeout() != null
+                || networkClientConfig.getSocketTimeout() != null) {
+            builder.setRequestConfigCallback(
+                    requestConfigBuilder -> {
+                        if (networkClientConfig.getConnectionRequestTimeout() != null) {
+                            requestConfigBuilder.setConnectionRequestTimeout(
+                                    networkClientConfig.getConnectionRequestTimeout());
+                        }
+                        if (networkClientConfig.getConnectionTimeout() != null) {
+                            requestConfigBuilder.setConnectTimeout(
+                                    networkClientConfig.getConnectionTimeout());
+                        }
+                        if (networkClientConfig.getSocketTimeout() != null) {
+                            requestConfigBuilder.setSocketTimeout(
+                                    networkClientConfig.getSocketTimeout());
+                        }
+                        return requestConfigBuilder;
+                    });
+        }
+        return builder;
+    }
+
+    private static SSLContext getSSLContext() throws IOException {
+        TrustManager[] trustAllCerts =
+                new TrustManager[] {
+                    new X509TrustManager() {
+                        @Override
+                        public void checkClientTrusted(
+                                java.security.cert.X509Certificate[] chain, String authType) {}
+
+                        @Override
+                        public void checkServerTrusted(
+                                java.security.cert.X509Certificate[] chain, String authType) {}
+
+                        @Override
+                        public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                            return new java.security.cert.X509Certificate[] {};
+                        }
+                    }
+                };
+
+        SSLContext sslContext = null;
+        try {
+            sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+
+        return sslContext;
+    }
+
+    private BulkProcessor<IN> createBulkProcessor(
+            BulkProcessorFactory<IN> bulkProcessorFactory,
+            BulkProcessorConfig bulkProcessorConfig) {
+
+        BulkProcessor.Builder<IN> builder =
+                bulkProcessorFactory.apply(
+                        client, bulkProcessorConfig, new Elasticsearch8Writer<IN>.BulkListener());
+
+        return builder.build();
+    }
+
+    private class BulkListener implements BulkProcessor.BulkListener<IN> {
+        @Override
+        public void beforeBulk(long executionId, BulkRequest request, List list) {
+            LOG.info("Sending bulk of {} actions to Elasticsearch.", request.operations());
+            lastSendTime = System.currentTimeMillis();
+            numBytesOutCounter.inc(request.operations().size());
+        }
+
+        @Override
+        public void afterBulk(
+                long executionId, BulkRequest request, List list, BulkResponse response) {
+            ackTime = System.currentTimeMillis();
+            enqueueActionInMailbox(
+                    () -> extractFailures(request, response), "elasticsearchSuccessCallback");
+        }
+
+        @Override
+        public void afterBulk(long executionId, BulkRequest request, List list, Throwable failure) {
+            enqueueActionInMailbox(
+                    () -> {
+                        throw new FlinkRuntimeException("Complete bulk has failed.", failure);
+                    },
+                    "elasticsearchErrorCallback");
+        }
+    }
+
+    private void enqueueActionInMailbox(
+            ThrowingRunnable<? extends Exception> action, String actionName) {
+        // If the writer is cancelled before the last bulk response (i.e. no flush on checkpoint
+        // configured or shutdown without a final
+        // checkpoint) the mailbox might already be shutdown, so we should not enqueue any
+        // actions.
+        if (isClosed()) {
+            return;
+        }
+        mailboxExecutor.execute(action, actionName);
+    }
+
+    private void extractFailures(BulkRequest request, BulkResponse response) {
+        if (!response.errors()) {
+            LOG.debug(
+                    "Current pendingActions: {}, dec: {}",
+                    pendingActions,
+                    request.operations().size());
+            pendingActions -= request.operations().size();
+            return;
+        }
+
+        Throwable chainedFailures = null;
+        for (int i = 0; i < response.items().size(); i++) {
+            BulkResponseItem itemResponse = response.items().get(i);
+            int status = itemResponse.status();
+            if (status == 0) {
+                continue;
+            }
+            ErrorCause failure = itemResponse.error();
+            if (failure == null) {
+                continue;
+            }
+            final BulkOperation bulkOperation = request.operations().get(i);
+            chainedFailures =
+                    firstOrSuppressed(
+                            wrapException(status, new Exception(failure.reason()), bulkOperation),
+                            chainedFailures);
+        }
+        if (chainedFailures == null) {
+            return;
+        }
+        LOG.error(chainedFailures.getMessage(), new FlinkRuntimeException(chainedFailures));
+        throw new FlinkRuntimeException(chainedFailures);
+    }
+
+    private static Throwable wrapException(
+            int restStatus, Throwable rootFailure, BulkOperation bulkOperation) {
+        return new FlinkRuntimeException(
+                String.format(
+                        "Single action %s of bulk request failed with status %s.",
+                        bulkOperation, restStatus),
+                rootFailure);
+    }
+
+    private boolean isClosed() {
+        if (closed) {
+            LOG.warn("Writer was closed before all records were acknowledged by Elasticsearch.");
+        }
+        return closed;
+    }
+
+    private class DefaultRequestIndexer implements RequestIndexer {
+
+        private final Counter numRecordsSendCounter;
+
+        public DefaultRequestIndexer(Counter numRecordsSendCounter) {
+            this.numRecordsSendCounter = checkNotNull(numRecordsSendCounter);
+        }
+
+        @Override
+        public void add(BulkOperation... operations) {
+            for (final BulkOperation operation : operations) {
+                numRecordsSendCounter.inc();
+                pendingActions++;
+                bulkProcessor.add(operation);
+            }
+        }
+    }
+}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/FlushBackoffType.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/FlushBackoffType.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Used to control whether the sink should retry failed requests at all or with which kind back off
+ * strategy.
+ */
+@PublicEvolving
+public enum FlushBackoffType {
+    /** After every failure, it waits a configured time until the retries are exhausted. */
+    CONSTANT,
+    /**
+     * After every failure, it waits initially the configured time and increases the waiting time
+     * exponentially until the retries are exhausted.
+     */
+    EXPONENTIAL,
+    /** The failure is not retried. */
+    NONE,
+}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/MapElasticsearchEmitter.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/MapElasticsearchEmitter.java
@@ -1,0 +1,70 @@
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.elasticsearch.bulk.RequestIndexer;
+
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.CreateOperation;
+import co.elastic.clients.elasticsearch.core.bulk.UpdateOperation;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/** A simple Elasticsearch8Emitter which is currently used in PyFlink ES connector. */
+public class MapElasticsearchEmitter implements Elasticsearch8Emitter<Map<String, Object>> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String index;
+    private @Nullable final String idFieldName;
+    private final boolean isDynamicIndex;
+    private transient Function<Map<String, Object>, String> indexProvider;
+
+    public MapElasticsearchEmitter(
+            String index,
+            @Nullable String idFieldName,
+            boolean isDynamicIndex,
+            Function<Map<String, Object>, String> indexProvider) {
+        this.index = index;
+        this.idFieldName = idFieldName;
+        this.isDynamicIndex = isDynamicIndex;
+        this.indexProvider = indexProvider;
+    }
+
+    @Override
+    public void open() throws Exception {
+        if (isDynamicIndex) {
+            indexProvider = doc -> doc.get(index).toString();
+        } else {
+            indexProvider = doc -> index;
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        Elasticsearch8Emitter.super.close();
+    }
+
+    @Override
+    public void emit(Map<String, Object> doc, SinkWriter.Context context, RequestIndexer indexer) {
+        if (idFieldName != null) {
+            UpdateOperation<Object, Object> updateOperation =
+                    UpdateOperation.of(
+                            b -> b.index(String.valueOf(index)).id(indexProvider.apply(doc))
+                                    .action(_3 -> _3.docAsUpsert(true).doc(doc)));
+            BulkOperation bulkOperation = BulkOperation.of(f -> f.update(updateOperation));
+            indexer.add(bulkOperation);
+        } else {
+            {
+                CreateOperation<Object> createOperation =
+                        CreateOperation.of(
+                                b -> b.index(String.valueOf(index)).id(indexProvider.apply(doc))
+                                        .document(doc));
+                BulkOperation bulkOperation = BulkOperation.of(f -> f.create(createOperation));
+                indexer.add(bulkOperation);
+            }
+        }
+    }
+}

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/NetworkClientConfig.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/NetworkClientConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+class NetworkClientConfig implements Serializable {
+
+    @Nullable private final String username;
+    @Nullable private final String password;
+    @Nullable private final String connectionPathPrefix;
+    @Nullable private final Integer connectionRequestTimeout;
+    @Nullable private final Integer connectionTimeout;
+    @Nullable private final Integer socketTimeout;
+
+    NetworkClientConfig(
+            @Nullable String username,
+            @Nullable String password,
+            @Nullable String connectionPathPrefix,
+            @Nullable Integer connectionRequestTimeout,
+            @Nullable Integer connectionTimeout,
+            @Nullable Integer socketTimeout) {
+        this.username = username;
+        this.password = password;
+        this.connectionPathPrefix = connectionPathPrefix;
+        this.connectionRequestTimeout = connectionRequestTimeout;
+        this.connectionTimeout = connectionTimeout;
+        this.socketTimeout = socketTimeout;
+    }
+
+    @Nullable
+    public String getUsername() {
+        return username;
+    }
+
+    @Nullable
+    public String getPassword() {
+        return password;
+    }
+
+    @Nullable
+    public Integer getConnectionRequestTimeout() {
+        return connectionRequestTimeout;
+    }
+
+    @Nullable
+    public Integer getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    @Nullable
+    public Integer getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    @Nullable
+    public String getConnectionPathPrefix() {
+        return connectionPathPrefix;
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/DockerImageVersions.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/DockerImageVersions.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch;
+
+import co.elastic.clients.transport.Version;
+
+/**
+ * Utility class for defining the image names and versions of Docker containers used during the Java
+ * tests. The names/versions are centralised here in order to make testing version updates easier,
+ * as well as to provide a central file to use as a key when caching testing Docker files.
+ */
+public class DockerImageVersions {
+
+    public static final String ELASTICSEARCH_8 =
+            "docker.elastic.co/elasticsearch/elasticsearch:8.9.1";
+
+    public static final Version getVersion(String dockerEsImage) {
+        return Version.parse(dockerEsImage.split(":")[1]);
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/ElasticsearchServerBaseITCase.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/ElasticsearchServerBaseITCase.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+
+/** Base test for Elasticsearch server. */
+public abstract class ElasticsearchServerBaseITCase {
+
+    protected static final Logger LOG =
+            LoggerFactory.getLogger(ElasticsearchServerBaseITCase.class);
+    protected static final String ELASTICSEARCH_PASSWORD = "test-password";
+    protected static final String ELASTICSEARCH_USER = "elastic";
+
+    public abstract SSLContext getSSLContext();
+
+    public abstract String getElasticsearchHttpHostAddress();
+
+    public abstract ElasticsearchClient createElasticsearch8Client();
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/ElasticsearchUtil.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/ElasticsearchUtil.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.slf4j.Logger;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Optional;
+
+/** Collection of utility methods for Elasticsearch tests. */
+@Internal
+public class ElasticsearchUtil {
+
+    private ElasticsearchUtil() {}
+
+    /**
+     * Creates a preconfigured {@link ElasticsearchContainer} with limited memory allocation and
+     * aligns the internal Elasticsearch log levels with the ones used by the capturing logger.
+     *
+     * @param dockerImageVersion describing the Elasticsearch image
+     * @param log to derive the log level from
+     * @return configured Elasticsearch container
+     */
+    public static ElasticsearchContainer createElasticsearchContainer(
+            String dockerImageVersion, Logger log) {
+        String logLevel;
+        if (log.isTraceEnabled()) {
+            logLevel = "TRACE";
+        } else if (log.isDebugEnabled()) {
+            logLevel = "DEBUG";
+        } else if (log.isInfoEnabled()) {
+            logLevel = "INFO";
+        } else if (log.isWarnEnabled()) {
+            logLevel = "WARN";
+        } else if (log.isErrorEnabled()) {
+            logLevel = "ERROR";
+        } else {
+            logLevel = "OFF";
+        }
+
+        return new ElasticsearchContainer(DockerImageName.parse(dockerImageVersion))
+                .withEnv("ES_JAVA_OPTS", "-Xms2g -Xmx2g")
+                .withEnv("logger.org.elasticsearch", logLevel)
+                .withLogConsumer(new Slf4jLogConsumer(log));
+    }
+
+    /** A mock {@link DynamicTableSink.Context} for Elasticsearch tests. */
+    public static class MockContext implements DynamicTableSink.Context {
+        @Override
+        public boolean isBounded() {
+            return false;
+        }
+
+        @Override
+        public TypeInformation<?> createTypeInformation(DataType consumedDataType) {
+            return null;
+        }
+
+        @Override
+        public TypeInformation<?> createTypeInformation(LogicalType consumedLogicalType) {
+            return null;
+        }
+
+        @Override
+        public DynamicTableSink.DataStructureConverter createDataStructureConverter(
+                DataType consumedDataType) {
+            return null;
+        }
+
+        public Optional<int[][]> getTargetColumns() {
+            return Optional.empty();
+        }
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/RequestTest.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/RequestTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch;
+
+import java.util.Objects;
+
+/** Entities for all unit tests. */
+public class RequestTest {
+    /** Product entity. */
+    public static class Product {
+
+        public double price;
+
+        public String name;
+
+        public Product() {}
+
+        public Product(double price) {
+            this.price = price;
+            this.name = "test-" + price;
+        }
+
+        public Product(double price, String name) {
+            this.price = price;
+            this.name = name;
+        }
+
+        public double getPrice() {
+            return price;
+        }
+
+        public void setPrice(double price) {
+            this.price = price;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Product product = (Product) o;
+            return Double.compare(product.price, price) == 0 && Objects.equals(name, product.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(price, name);
+        }
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/bulk/BulkProcessorTest.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/bulk/BulkProcessorTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.bulk;
+
+import org.apache.flink.connector.elasticsearch.DockerImageVersions;
+import org.apache.flink.connector.elasticsearch.ElasticsearchServerBaseITCase;
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
+import org.apache.flink.connector.elasticsearch.RequestTest;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.Version;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.net.ssl.SSLContext;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests for {@link BulkProcessor}. */
+@Testcontainers
+public class BulkProcessorTest extends ElasticsearchServerBaseITCase {
+
+    @Container
+    private static final ElasticsearchContainer ES_CONTAINER =
+            ElasticsearchUtil.createElasticsearchContainer(DockerImageVersions.ELASTICSEARCH_8, LOG)
+                    .withPassword(ELASTICSEARCH_PASSWORD);
+
+    private static final Version version =
+            DockerImageVersions.getVersion(DockerImageVersions.ELASTICSEARCH_8);
+
+    private static final boolean useTLS = version.major() >= 8;
+
+    private ElasticsearchClient client;
+
+    @Override
+    public SSLContext getSSLContext() {
+        return useTLS ? ES_CONTAINER.createSslContextFromCa() : null;
+    }
+
+    @Override
+    public String getElasticsearchHttpHostAddress() {
+        String schema = useTLS ? "https" : "http";
+        return schema + "://" + ES_CONTAINER.getHttpHostAddress();
+    }
+
+    @Override
+    public ElasticsearchClient createElasticsearch8Client() {
+        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(
+                AuthScope.ANY,
+                new UsernamePasswordCredentials(ELASTICSEARCH_USER, ELASTICSEARCH_PASSWORD));
+        HttpHost host = HttpHost.create(getElasticsearchHttpHostAddress());
+        RestClient httpClient =
+                RestClient.builder(host)
+                        .setHttpClientConfigCallback(
+                                hc ->
+                                        hc.setDefaultCredentialsProvider(credentialsProvider)
+                                                .setSSLContext(getSSLContext()))
+                        .build();
+        ElasticsearchTransport transport =
+                new RestClientTransport(httpClient, new JacksonJsonpMapper());
+        return new ElasticsearchClient(transport);
+    }
+
+    private static final BulkOperation operation =
+            BulkOperation.of(
+                    op ->
+                            op.create(
+                                    d ->
+                                            d.index("foo")
+                                                    .id("bar")
+                                                    .document(new RequestTest.Product(10))));
+
+    private void printStats(BulkProcessor<?> processor) {
+        System.out.printf(
+                "BulkProcessor - operations: %d (%d), requests: %d (%d)%n",
+                processor.operationsCount(),
+                processor.operationContentionsCount(),
+                processor.requestCount(),
+                processor.requestContentionsCount());
+    }
+
+    private void printStats(CountingListener listener) {
+        System.out.printf(
+                "Listener - operations: %d, requests: %d%n",
+                listener.operations.get(), listener.requests.get());
+    }
+
+    @BeforeEach
+    public void beforeAll() throws IOException {
+        client = createElasticsearch8Client();
+        client.indices().create(c -> c.index("foo"));
+    }
+
+    @Test
+    public void basicTestFlush() throws Exception {
+        // Prime numbers, so that we have leftovers to flush before shutting down
+        multiThreadTest(7, 3, 5, 101, operation);
+    }
+
+    private void multiThreadTest(
+            int maxOperations,
+            int maxRequests,
+            int numThreads,
+            int numOperations,
+            BulkOperation operation)
+            throws Exception {
+        CountingListener listener = new CountingListener();
+        BulkProcessor<Void> bulkProcessor =
+                BulkProcessor.of(
+                        b ->
+                                b.client(client)
+                                        .maxOperations(maxOperations)
+                                        .maxConcurrentRequests(maxRequests)
+                                        .listener(listener));
+
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        for (int i = 0; i < numThreads; i++) {
+            new Thread(
+                            () -> {
+                                try {
+                                    Thread.sleep((long) (Math.random() * 100));
+                                } catch (InterruptedException e) {
+                                    throw new RuntimeException(e);
+                                }
+                                for (int j = 0; j < numOperations; j++) {
+                                    bulkProcessor.add(operation);
+                                }
+
+                                latch.countDown();
+                            })
+                    .start();
+        }
+
+        latch.await();
+        bulkProcessor.flush();
+        bulkProcessor.close();
+        client.shutdown();
+
+        printStats(bulkProcessor);
+        printStats(listener);
+
+        int expectedOperations = numThreads * numOperations;
+        assertEquals(expectedOperations, bulkProcessor.operationsCount());
+        assertEquals(expectedOperations, listener.operations.get());
+
+        int expectedRequests =
+                expectedOperations / maxOperations
+                        + ((expectedOperations % maxOperations == 0) ? 0 : 1);
+
+        assertEquals(expectedRequests, bulkProcessor.requestCount());
+        assertEquals(expectedRequests, listener.requests.get());
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    private static class CountingListener implements BulkProcessor.BulkListener<Void> {
+        public final AtomicInteger operations = new AtomicInteger();
+        public final AtomicInteger requests = new AtomicInteger();
+
+        @Override
+        public void beforeBulk(long executionId, BulkRequest request, List<Void> contexts) {}
+
+        @Override
+        public void afterBulk(
+                long executionId, BulkRequest request, List<Void> contexts, BulkResponse response) {
+            operations.addAndGet(request.operations().size());
+            requests.incrementAndGet();
+        }
+
+        @Override
+        public void afterBulk(
+                long executionId, BulkRequest request, List<Void> contexts, Throwable failure) {
+            failure.printStackTrace();
+            operations.addAndGet(request.operations().size());
+            requests.incrementAndGet();
+        }
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/server/Elasticsearch8Test.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/server/Elasticsearch8Test.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.server;
+
+import org.apache.flink.connector.elasticsearch.DockerImageVersions;
+import org.apache.flink.connector.elasticsearch.ElasticsearchServerBaseITCase;
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
+import org.apache.flink.connector.elasticsearch.RequestTest;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.GetRequest;
+import co.elastic.clients.elasticsearch.core.GetResponse;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.Version;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.net.ssl.SSLContext;
+
+import java.io.IOException;
+
+/** Tests for elasticsearch 8 server and client. */
+@Testcontainers
+public class Elasticsearch8Test extends ElasticsearchServerBaseITCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Elasticsearch8Test.class);
+
+    protected static final String ELASTICSEARCH_PASSWORD = "test-password";
+
+    @Container
+    private static final ElasticsearchContainer ES_CONTAINER =
+            ElasticsearchUtil.createElasticsearchContainer(DockerImageVersions.ELASTICSEARCH_8, LOG)
+                    .withPassword(ELASTICSEARCH_PASSWORD);
+
+    private static final Version version =
+            DockerImageVersions.getVersion(DockerImageVersions.ELASTICSEARCH_8);
+
+    private static final boolean useTLS = version.major() >= 8;
+
+    @Override
+    public SSLContext getSSLContext() {
+        return useTLS ? ES_CONTAINER.createSslContextFromCa() : null;
+    }
+
+    @Override
+    public String getElasticsearchHttpHostAddress() {
+        String schema = useTLS ? "https" : "http";
+        return schema + "://" + ES_CONTAINER.getHttpHostAddress();
+    }
+
+    @Override
+    public ElasticsearchClient createElasticsearch8Client() {
+        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(
+                AuthScope.ANY,
+                new UsernamePasswordCredentials(ELASTICSEARCH_USER, ELASTICSEARCH_PASSWORD));
+        HttpHost host = HttpHost.create(getElasticsearchHttpHostAddress());
+        RestClient httpClient =
+                RestClient.builder(host)
+                        .setHttpClientConfigCallback(
+                                hc ->
+                                        hc.setDefaultCredentialsProvider(credentialsProvider)
+                                                .setSSLContext(getSSLContext()))
+                        .build();
+        ElasticsearchTransport transport =
+                new RestClientTransport(httpClient, new JacksonJsonpMapper());
+        return new ElasticsearchClient(transport);
+    }
+
+    @Test
+    public void testServer() throws IOException {
+        SSLContext sslContext = ES_CONTAINER.createSslContextFromCa();
+        final BasicCredentialsProvider credsProv = new BasicCredentialsProvider();
+        credsProv.setCredentials(
+                AuthScope.ANY, new UsernamePasswordCredentials("elastic", ELASTICSEARCH_PASSWORD));
+        HttpHost httpHost = HttpHost.create("https://" + ES_CONTAINER.getHttpHostAddress());
+        RestClient restClient =
+                RestClient.builder(httpHost)
+                        .setHttpClientConfigCallback(
+                                hc ->
+                                        hc.setSSLContext(sslContext)
+                                                .setDefaultCredentialsProvider(credsProv))
+                        .build();
+
+        // Note: client.helthReport() has some errors, we need to check in the future.
+        // Create the transport with a Jackson mapper
+        // ElasticsearchTransport transport =
+        //       new RestClientTransport(restClient, new JacksonJsonpMapper());
+
+        // And create the API client
+        // ElasticsearchClient esClient = new ElasticsearchClient(transport);
+        // esClient.healthReport();
+
+        Request request = new Request("GET", "_cluster/health");
+        Response resp = restClient.performRequest(request);
+        Assert.assertEquals(200, resp.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void testClient() throws IOException {
+        ElasticsearchClient esClient = createElasticsearch8Client();
+        esClient.indices().create(c -> c.index("products"));
+        esClient.index(i -> i.index("products").id("A").document(new RequestTest.Product(10)));
+        GetResponse<RequestTest.Product> getResponse =
+                esClient.get(
+                        GetRequest.of(b -> b.index("products").id("A")), RequestTest.Product.class);
+        Assert.assertTrue(getResponse.found());
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8SinkBaseITCase.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8SinkBaseITCase.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.elasticsearch.ElasticsearchServerBaseITCase;
+import org.apache.flink.connector.elasticsearch.RequestTest;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.junit.ClassRule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.BiFunction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link Elasticsearch8Sink}. */
+@ExtendWith(TestLoggerExtension.class)
+abstract class Elasticsearch8SinkBaseITCase extends ElasticsearchServerBaseITCase {
+
+    @ClassRule @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(3)
+                            .build());
+
+    protected static final Logger LOG = LoggerFactory.getLogger(Elasticsearch8SinkBaseITCase.class);
+    protected static final String ELASTICSEARCH_PASSWORD = "test-password";
+    protected static final String ELASTICSEARCH_USER = "elastic";
+
+    private static boolean failed;
+
+    private ElasticsearchClient client;
+    private TestClientBase context;
+
+    abstract TestClientBase createTestClient(ElasticsearchClient client);
+
+    abstract Elasticsearch8SinkBuilderBase<
+                    Tuple2<Integer, RequestTest.Product>, ? extends Elasticsearch8SinkBuilderBase>
+            getSinkBuilder();
+
+    public ElasticsearchClient createElasticsearch8Client() {
+
+        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(
+                AuthScope.ANY,
+                new UsernamePasswordCredentials(ELASTICSEARCH_USER, ELASTICSEARCH_PASSWORD));
+        HttpHost host = HttpHost.create(getElasticsearchHttpHostAddress());
+        RestClient httpClient =
+                RestClient.builder(host)
+                        .setHttpClientConfigCallback(
+                                hc ->
+                                        hc.setDefaultCredentialsProvider(credentialsProvider)
+                                                .setSSLContext(getSSLContext()))
+                        .build();
+        ElasticsearchTransport transport =
+                new RestClientTransport(httpClient, new JacksonJsonpMapper());
+        return new ElasticsearchClient(transport);
+    }
+
+    @BeforeEach
+    void setUp() {
+        failed = false;
+        client = createElasticsearch8Client();
+        context = createTestClient(client);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (client != null) {
+            client.shutdown();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(DeliveryGuarantee.class)
+    void testWriteToElasticSearchWithDeliveryGuarantee(DeliveryGuarantee deliveryGuarantee)
+            throws Exception {
+        final String index = "test-es-with-delivery-" + deliveryGuarantee;
+        boolean failure = false;
+        try {
+            runTest(index, false, TestEmitter8::jsonEmitter, deliveryGuarantee, null);
+        } catch (IllegalStateException e) {
+            failure = true;
+            assertThat(deliveryGuarantee).isSameAs(DeliveryGuarantee.EXACTLY_ONCE);
+        } finally {
+            assertThat(failure).isEqualTo(deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("elasticsearchEmitters")
+    void testWriteJsonToElasticsearch(
+            BiFunction<String, String, Elasticsearch8Emitter<Tuple2<Integer, RequestTest.Product>>>
+                    emitterProvider)
+            throws Exception {
+        final String index = "test-elasticsearch-sink-" + UUID.randomUUID();
+        runTest(index, false, emitterProvider, null);
+    }
+
+    @Test
+    void testRecovery() throws Exception {
+        final String index = "test-recovery-elasticsearch-sink";
+        runTest(index, true, TestEmitter8::jsonEmitter, new FailingMapper());
+        assertThat(failed).isTrue();
+    }
+
+    private void runTest(
+            String index,
+            boolean allowRestarts,
+            BiFunction<String, String, Elasticsearch8Emitter<Tuple2<Integer, RequestTest.Product>>>
+                    emitterProvider,
+            @Nullable MapFunction<Long, Long> additionalMapper)
+            throws Exception {
+        runTest(
+                index,
+                allowRestarts,
+                emitterProvider,
+                DeliveryGuarantee.AT_LEAST_ONCE,
+                additionalMapper);
+    }
+
+    private void runTest(
+            String index,
+            boolean allowRestarts,
+            BiFunction<String, String, Elasticsearch8Emitter<Tuple2<Integer, RequestTest.Product>>>
+                    emitterProvider,
+            DeliveryGuarantee deliveryGuarantee,
+            @Nullable MapFunction<Long, Long> additionalMapper)
+            throws Exception {
+        final Elasticsearch8Sink<Tuple2<Integer, RequestTest.Product>> sink =
+                getSinkBuilder()
+                        .setHosts(HttpHost.create(getElasticsearchHttpHostAddress()))
+                        .setSSLContext(getSSLContext())
+                        .setEmitter(emitterProvider.apply(index, context.getDataFieldName()))
+                        .setBulkFlushMaxActions(5)
+                        .setConnectionUsername(ELASTICSEARCH_USER)
+                        .setConnectionPassword(ELASTICSEARCH_PASSWORD)
+                        .setDeliveryGuarantee(deliveryGuarantee)
+                        .build();
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(100L);
+        if (!allowRestarts) {
+            env.setRestartStrategy(RestartStrategies.noRestart());
+        }
+        DataStream<Long> stream = env.fromSequence(1, 5);
+
+        if (additionalMapper != null) {
+            stream = stream.map(additionalMapper);
+        }
+        stream.map(
+                        new MapFunction<Long, Tuple2<Integer, RequestTest.Product>>() {
+                            @Override
+                            public Tuple2<Integer, RequestTest.Product> map(Long value)
+                                    throws Exception {
+                                return Tuple2.of(
+                                        value.intValue(),
+                                        TestClientBase.buildMessage(value.intValue()));
+                            }
+                        })
+                .sinkTo(sink);
+        env.execute();
+        context.assertThatIdsAreWritten(index, 1, 2, 3, 4, 5);
+    }
+
+    private static List<
+                    BiFunction<
+                            String,
+                            String,
+                            Elasticsearch8Emitter<Tuple2<Integer, RequestTest.Product>>>>
+            elasticsearchEmitters() {
+        return Lists.newArrayList(TestEmitter8::jsonEmitter);
+    }
+
+    private static class FailingMapper implements MapFunction<Long, Long>, CheckpointListener {
+
+        private int emittedRecords = 0;
+
+        @Override
+        public Long map(Long value) throws Exception {
+            Thread.sleep(50);
+            emittedRecords++;
+            return value;
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) throws Exception {
+            if (failed || emittedRecords == 0) {
+                return;
+            }
+            failed = true;
+            throw new Exception("Expected failure");
+        }
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8SinkBuilderBaseTest.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8SinkBuilderBaseTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.apache.http.HttpHost;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+/** Tests for {@link Elasticsearch8SinkBuilderBase}. */
+@ExtendWith(TestLoggerExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class Elasticsearch8SinkBuilderBaseTest<
+        B extends Elasticsearch8SinkBuilderBase<Object, B>> {
+
+    @TestFactory
+    Stream<DynamicTest> testValidBuilders() {
+        Stream<B> validBuilders =
+                Stream.of(
+                        createMinimalBuilder(),
+                        createMinimalBuilder()
+                                .setDeliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE),
+                        createMinimalBuilder()
+                                .setBulkFlushBackoffStrategy(FlushBackoffType.CONSTANT, 1, 1),
+                        createMinimalBuilder()
+                                .setConnectionUsername("username")
+                                .setConnectionPassword("password"));
+
+        return DynamicTest.stream(
+                validBuilders,
+                Elasticsearch8SinkBuilderBase::toString,
+                builder -> assertThatCode(builder::build).doesNotThrowAnyException());
+    }
+
+    @Test
+    void testDefaultDeliveryGuarantee() {
+        assertThat(createMinimalBuilder().build().getDeliveryGuarantee())
+                .isEqualTo(DeliveryGuarantee.AT_LEAST_ONCE);
+    }
+
+    @Test
+    void testThrowIfExactlyOnceConfigured() {
+        assertThatThrownBy(
+                        () ->
+                                createMinimalBuilder()
+                                        .setDeliveryGuarantee(DeliveryGuarantee.EXACTLY_ONCE))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testThrowIfHostsNotSet() {
+        assertThatThrownBy(
+                        () ->
+                                createEmptyBuilder()
+                                        .setEmitter((element, indexer, context) -> {})
+                                        .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testThrowIfEmitterNotSet() {
+        assertThatThrownBy(
+                        () -> createEmptyBuilder().setHosts(new HttpHost("https://localhost:3000")).build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testThrowIfSetInvalidTimeouts() {
+        assertThatThrownBy(() -> createEmptyBuilder().setConnectionRequestTimeout(-1).build())
+                .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> createEmptyBuilder().setConnectionTimeout(-1).build())
+                .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> createEmptyBuilder().setSocketTimeout(-1).build())
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    abstract B createEmptyBuilder();
+
+    abstract B createMinimalBuilder();
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8SinkBuilderTest.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8SinkBuilderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.http.HttpHost;
+
+/** Tests for {@link Elasticsearch8SinkBuilder}. */
+class Elasticsearch8SinkBuilderTest
+        extends Elasticsearch8SinkBuilderBaseTest<Elasticsearch8SinkBuilder<Object>> {
+
+    @Override
+    Elasticsearch8SinkBuilder<Object> createEmptyBuilder() {
+        return new Elasticsearch8SinkBuilder<>();
+    }
+
+    @Override
+    Elasticsearch8SinkBuilder<Object> createMinimalBuilder() {
+        return new Elasticsearch8SinkBuilder<>()
+                .setEmitter((element, indexer, context) -> {})
+                .setHosts(new HttpHost("https://localhost:3000"));
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8SinkITCase.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8SinkITCase.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.elasticsearch.DockerImageVersions;
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
+import org.apache.flink.connector.elasticsearch.RequestTest;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.transport.Version;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.net.ssl.SSLContext;
+
+/** Tests for {@link Elasticsearch8Sink}. */
+@Testcontainers
+class Elasticsearch8SinkITCase extends Elasticsearch8SinkBaseITCase {
+
+    @Container
+    private static final ElasticsearchContainer ES_CONTAINER =
+            ElasticsearchUtil.createElasticsearchContainer(DockerImageVersions.ELASTICSEARCH_8, LOG)
+                    .withPassword(ELASTICSEARCH_PASSWORD);
+
+    private static final Version version =
+            DockerImageVersions.getVersion(DockerImageVersions.ELASTICSEARCH_8);
+
+    private static final boolean useTLS = version.major() >= 8;
+
+    @Override
+    public SSLContext getSSLContext() {
+        return useTLS ? ES_CONTAINER.createSslContextFromCa() : null;
+    }
+
+    @Override
+    public String getElasticsearchHttpHostAddress() {
+        String schema = useTLS ? "https" : "http";
+        return schema + "://" + ES_CONTAINER.getHttpHostAddress();
+    }
+
+    @Override
+    TestClientBase createTestClient(ElasticsearchClient client) {
+        return new Elasticsearch8TestClient(client);
+    }
+
+    @Override
+    Elasticsearch8SinkBuilderBase<
+                    Tuple2<Integer, RequestTest.Product>, ? extends Elasticsearch8SinkBuilderBase>
+            getSinkBuilder() {
+        return new Elasticsearch8SinkBuilder<>();
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8TestClient.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8TestClient.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.GetRequest;
+import co.elastic.clients.elasticsearch.core.GetResponse;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+class Elasticsearch8TestClient extends TestClientBase {
+
+    Elasticsearch8TestClient(ElasticsearchClient client) {
+        super(client);
+    }
+
+    @Override
+    GetResponse getResponse(String index, int id) throws IOException {
+        Type type = new TypeReference<JacksonJsonpMapper>() {}.getType();
+        return client.get(GetRequest.of(b -> b.index(index).id(String.valueOf(id))), type);
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8WriterITCase.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8WriterITCase.java
@@ -1,0 +1,483 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.elasticsearch.DockerImageVersions;
+import org.apache.flink.connector.elasticsearch.ElasticsearchServerBaseITCase;
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
+import org.apache.flink.connector.elasticsearch.RequestTest;
+import org.apache.flink.connector.elasticsearch.bulk.BulkProcessor;
+import org.apache.flink.connector.elasticsearch.bulk.RequestIndexer;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.metrics.testutils.MetricListener;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.TestLoggerExtension;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch.core.GetRequest;
+import co.elastic.clients.elasticsearch.core.GetResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.CreateOperation;
+import co.elastic.clients.elasticsearch.core.bulk.DeleteOperation;
+import co.elastic.clients.elasticsearch.core.bulk.UpdateOperation;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.Version;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.net.ssl.SSLContext;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.connector.elasticsearch.sink.TestClientBase.buildMessage;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link Elasticsearch8Writer}. */
+@Testcontainers
+@ExtendWith(TestLoggerExtension.class)
+class Elasticsearch8WriterITCase extends ElasticsearchServerBaseITCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Elasticsearch8WriterITCase.class);
+
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(3)
+                            .build());
+
+    @Container
+    private static final ElasticsearchContainer ES_CONTAINER =
+            ElasticsearchUtil.createElasticsearchContainer(DockerImageVersions.ELASTICSEARCH_8, LOG)
+                    .withPassword(ELASTICSEARCH_PASSWORD);
+
+    private static final Version version =
+            DockerImageVersions.getVersion(DockerImageVersions.ELASTICSEARCH_8);
+
+    private static final boolean useTLS = version.major() >= 8;
+
+    @Override
+    public SSLContext getSSLContext() {
+        return useTLS ? ES_CONTAINER.createSslContextFromCa() : null;
+    }
+
+    @Override
+    public String getElasticsearchHttpHostAddress() {
+        String schema = useTLS ? "https" : "http";
+        return schema + "://" + ES_CONTAINER.getHttpHostAddress();
+    }
+
+    private ElasticsearchClient client;
+    private TestClientBase context;
+    private MetricListener metricListener;
+
+    @BeforeEach
+    void setUp() {
+        metricListener = new MetricListener();
+        client = createElasticsearch8Client();
+        context = new TestClient(client);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (client != null) {
+            client.shutdown();
+        }
+    }
+
+    @Override
+    public ElasticsearchClient createElasticsearch8Client() {
+        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(
+                AuthScope.ANY,
+                new UsernamePasswordCredentials(ELASTICSEARCH_USER, ELASTICSEARCH_PASSWORD));
+        HttpHost host = HttpHost.create(getElasticsearchHttpHostAddress());
+        RestClient httpClient =
+                RestClient.builder(host)
+                        .setHttpClientConfigCallback(
+                                hc ->
+                                        hc.setDefaultCredentialsProvider(credentialsProvider)
+                                                .setSSLContext(getSSLContext()))
+                        .build();
+        ElasticsearchTransport transport =
+                new RestClientTransport(httpClient, new JacksonJsonpMapper());
+        return new ElasticsearchClient(transport);
+    }
+
+    @Test
+    void testWriteOnBulkFlush() throws Exception {
+        final String index = "test-bulk-flush-without-checkpoint";
+        final int flushAfterNActions = 5;
+        final BulkProcessorConfig bulkProcessorConfig =
+                new BulkProcessorConfig(
+                        flushAfterNActions, 10000, 10000, FlushBackoffType.NONE, 3, 10000);
+
+        try (final Elasticsearch8Writer<Tuple2<Integer, RequestTest.Product>> writer =
+                createWriter(index, false, bulkProcessorConfig)) {
+            writer.write(Tuple2.of(1, buildMessage(1)), null);
+            writer.write(Tuple2.of(2, buildMessage(2)), null);
+            writer.write(Tuple2.of(3, buildMessage(3)), null);
+            writer.write(Tuple2.of(4, buildMessage(4)), null);
+
+            // Ignore flush on checkpoint
+            writer.flush(false);
+
+            context.assertThatIdsAreNotWritten(index, 1, 2, 3, 4);
+
+            // Trigger flush
+            writer.write(Tuple2.of(5, buildMessage(5)), null);
+            Thread.sleep(10);
+            context.assertThatIdsAreWritten(index, 1, 2, 3, 4, 5);
+
+            writer.write(Tuple2.of(6, buildMessage(6)), null);
+            context.assertThatIdsAreNotWritten(index, 6);
+
+            // Force flush
+            writer.blockingFlushAllActions();
+            context.assertThatIdsAreWritten(index, 1, 2, 3, 4, 5, 6);
+        }
+    }
+
+    @Test
+    void testWriteOnBulkIntervalFlush() throws Exception {
+        final String index = "test-bulk-flush-with-interval";
+
+        // Configure bulk processor to flush every 1s;
+        final BulkProcessorConfig bulkProcessorConfig =
+                new BulkProcessorConfig(-1, -1, 1000, FlushBackoffType.NONE, 0, 0);
+
+        try (final Elasticsearch8Writer<Tuple2<Integer, RequestTest.Product>> writer =
+                createWriter(index, false, bulkProcessorConfig)) {
+            writer.write(Tuple2.of(1, buildMessage(1)), null);
+            writer.write(Tuple2.of(2, buildMessage(2)), null);
+            writer.write(Tuple2.of(3, buildMessage(3)), null);
+            writer.write(Tuple2.of(4, buildMessage(4)), null);
+            writer.blockingFlushAllActions();
+        }
+
+        context.assertThatIdsAreWritten(index, 1, 2, 3, 4);
+    }
+
+    @Test
+    void testWriteOnCheckpoint() throws Exception {
+        final String index = "test-bulk-flush-with-checkpoint";
+        final BulkProcessorConfig bulkProcessorConfig =
+                new BulkProcessorConfig(-1, -1, -1, FlushBackoffType.NONE, 0, 0);
+
+        // Enable flush on checkpoint
+        try (final Elasticsearch8Writer<Tuple2<Integer, RequestTest.Product>> writer =
+                createWriter(index, true, bulkProcessorConfig)) {
+            writer.write(Tuple2.of(1, buildMessage(1)), null);
+            writer.write(Tuple2.of(2, buildMessage(2)), null);
+            writer.write(Tuple2.of(3, buildMessage(3)), null);
+
+            context.assertThatIdsAreNotWritten(index, 1, 2, 3);
+
+            // Trigger flush
+            writer.flush(false);
+
+            context.assertThatIdsAreWritten(index, 1, 2, 3);
+        }
+    }
+
+    @Test
+    void testIncrementByteOutMetric() throws Exception {
+        final String index = "test-inc-byte-out";
+        final OperatorIOMetricGroup operatorIOMetricGroup =
+                UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup().getIOMetricGroup();
+        final InternalSinkWriterMetricGroup metricGroup =
+                InternalSinkWriterMetricGroup.mock(
+                        metricListener.getMetricGroup(), operatorIOMetricGroup);
+        final int flushAfterNActions = 2;
+        final BulkProcessorConfig bulkProcessorConfig =
+                new BulkProcessorConfig(flushAfterNActions, -1, -1, FlushBackoffType.NONE, 0, 0);
+
+        try (final Elasticsearch8Writer<Tuple2<Integer, RequestTest.Product>> writer =
+                createWriter(index, false, bulkProcessorConfig, metricGroup)) {
+            final Counter numBytesOut = operatorIOMetricGroup.getNumBytesOutCounter();
+            assertThat(numBytesOut.getCount()).isZero();
+            writer.write(Tuple2.of(1, buildMessage(1)), null);
+            writer.write(Tuple2.of(2, buildMessage(2)), null);
+
+            writer.blockingFlushAllActions();
+            long first = numBytesOut.getCount();
+            assertThat(first).isGreaterThan(0);
+
+            writer.write(Tuple2.of(3, buildMessage(4)), null);
+            writer.write(Tuple2.of(4, buildMessage(4)), null);
+
+            writer.blockingFlushAllActions();
+            assertThat(numBytesOut.getCount()).isGreaterThan(first);
+        }
+    }
+
+    @Test
+    void testIncrementRecordsSendMetric() throws Exception {
+        final String index = "test-inc-records-send";
+        final int flushAfterNActions = 2;
+        final BulkProcessorConfig bulkProcessorConfig =
+                new BulkProcessorConfig(flushAfterNActions, -1, -1, FlushBackoffType.NONE, 0, 0);
+
+        try (final Elasticsearch8Writer<Tuple2<Integer, RequestTest.Product>> writer =
+                createWriter(index, false, bulkProcessorConfig)) {
+            final Optional<Counter> recordsSend =
+                    metricListener.getCounter(MetricNames.NUM_RECORDS_SEND);
+            writer.write(Tuple2.of(1, buildMessage(1)), null);
+            // Update existing index
+            writer.write(Tuple2.of(1, buildMessage(2, "u" + "test_" + 2)), null);
+            // Delete index
+            writer.write(Tuple2.of(1, buildMessage(3, "d" + "test_" + 2)), null);
+
+            writer.blockingFlushAllActions();
+
+            assertThat(recordsSend).isPresent();
+            assertThat(recordsSend.get().getCount()).isEqualTo(3L);
+        }
+    }
+
+    @Test
+    void testCurrentSendTime() throws Exception {
+        final String index = "test-current-send-time";
+        final int flushAfterNActions = 2;
+        final BulkProcessorConfig bulkProcessorConfig =
+                new BulkProcessorConfig(flushAfterNActions, -1, -1, FlushBackoffType.NONE, 0, 0);
+
+        try (final Elasticsearch8Writer<Tuple2<Integer, RequestTest.Product>> writer =
+                createWriter(index, false, bulkProcessorConfig)) {
+            final Optional<Gauge<Long>> currentSendTime =
+                    metricListener.getGauge("currentSendTime");
+            writer.write(Tuple2.of(1, buildMessage(1)), null);
+            writer.write(Tuple2.of(2, buildMessage(2)), null);
+
+            writer.blockingFlushAllActions();
+
+            assertThat(currentSendTime).isPresent();
+            assertThat(currentSendTime.get().getValue()).isGreaterThan(0L);
+        }
+    }
+
+    private Elasticsearch8Writer<Tuple2<Integer, RequestTest.Product>> createWriter(
+            String index, boolean flushOnCheckpoint, BulkProcessorConfig bulkProcessorConfig)
+            throws Exception {
+        return createWriter(
+                index,
+                flushOnCheckpoint,
+                bulkProcessorConfig,
+                InternalSinkWriterMetricGroup.mock(metricListener.getMetricGroup()));
+    }
+
+    private Elasticsearch8Writer<Tuple2<Integer, RequestTest.Product>> createWriter(
+            String index,
+            boolean flushOnCheckpoint,
+            BulkProcessorConfig bulkProcessorConfig,
+            SinkWriterMetricGroup metricGroup)
+            throws Exception {
+        return new Elasticsearch8Writer<Tuple2<Integer, RequestTest.Product>>(
+                Collections.singletonList(HttpHost.create(getElasticsearchHttpHostAddress())),
+                getSSLContext(),
+                new TestingEmitter(index, context.getDataFieldName()),
+                flushOnCheckpoint,
+                bulkProcessorConfig,
+                getBulkProcessorBuilderFactory(),
+                new NetworkClientConfig("elastic", ELASTICSEARCH_PASSWORD, null, null, null, null),
+                metricGroup,
+                new TestMailbox());
+    }
+
+    protected BulkProcessorFactory<Tuple2<Integer, RequestTest.Product>>
+            getBulkProcessorBuilderFactory() {
+        return new BulkProcessorFactory<Tuple2<Integer, RequestTest.Product>>() {
+            @Override
+            public BulkProcessor.Builder<Tuple2<Integer, RequestTest.Product>> apply(
+                    ElasticsearchClient client,
+                    BulkProcessorConfig bulkProcessorConfig,
+                    BulkProcessor.BulkListener<Tuple2<Integer, RequestTest.Product>> listener) {
+                BulkProcessor.Builder<Tuple2<Integer, RequestTest.Product>> builder =
+                        BulkProcessor.ofBuilder(
+                                b ->
+                                        b.client(client)
+                                                .listener(listener)
+                                                .maxOperations(
+                                                        bulkProcessorConfig
+                                                                .getBulkFlushMaxActions())
+                                                .maxSize(bulkProcessorConfig.getBulkFlushMaxMb())
+                                                .flushInterval(
+                                                        bulkProcessorConfig.getBulkFlushInterval(),
+                                                        TimeUnit.MILLISECONDS));
+                return builder;
+            }
+        };
+    }
+
+    private static class TestingEmitter
+            implements Elasticsearch8Emitter<Tuple2<Integer, RequestTest.Product>> {
+
+        private final String dataFieldName;
+        private final String index;
+
+        TestingEmitter(String index, String dataFieldName) {
+            this.index = index;
+            this.dataFieldName = dataFieldName;
+        }
+
+        @Override
+        public void emit(
+                Tuple2<Integer, RequestTest.Product> element,
+                SinkWriter.Context context,
+                RequestIndexer indexer) {
+
+            final char action = element.f1.name.charAt(0);
+            final String id = element.f0.toString();
+            switch (action) {
+                case 'd':
+                    {
+                        DeleteOperation deleteOperation =
+                                DeleteOperation.of(b -> b.index(String.valueOf(index)).id(id));
+                        BulkOperation bulkOperation =
+                                BulkOperation.of(f -> f.delete(deleteOperation));
+                        indexer.add(bulkOperation);
+                        break;
+                    }
+                case 'u':
+                    {
+                        UpdateOperation<Object, Object> updateOperation =
+                                UpdateOperation.of(
+                                        b ->
+                                                b.index(String.valueOf(index))
+                                                        .id(id)
+                                                        .action(
+                                                                _3 ->
+                                                                        _3.docAsUpsert(true)
+                                                                                .doc(element.f1)));
+                        BulkOperation bulkOperation =
+                                BulkOperation.of(f -> f.update(updateOperation));
+                        indexer.add(bulkOperation);
+                        break;
+                    }
+                default:
+                    {
+                        CreateOperation<Object> createOperation =
+                                CreateOperation.of(
+                                        b ->
+                                                b.index(String.valueOf(index))
+                                                        .id(id)
+                                                        .document(element.f1));
+                        BulkOperation bulkOperation =
+                                BulkOperation.of(f -> f.create(createOperation));
+                        indexer.add(bulkOperation);
+                    }
+            }
+        }
+    }
+
+    private static class TestClient extends TestClientBase {
+
+        TestClient(ElasticsearchClient client) {
+            super(client);
+        }
+
+        @Override
+        GetResponse getResponse(String index, int id) throws ElasticsearchException, IOException {
+            GetRequest getRequest = GetRequest.of(f -> f.index(index).id(Integer.toString(id)));
+            int retry = 3;
+            while (retry > 0) {
+                try {
+                    retry--;
+                    return client.get(
+                            getRequest, new TypeReference<RequestTest.Product>() {}.getType());
+                } catch (ElasticsearchException e) {
+                    try {
+
+                        Thread.sleep(3);
+                    } catch (InterruptedException ex) {
+                        throw new RuntimeException(ex);
+                    }
+                    if (retry == 1) {
+                        LOG.warn("Get response failed", e);
+                    }
+                } catch (ResponseException re) {
+                    // Note: Catch this exception until the data is written successfully
+                    if (re.getMessage().contains("no_shard_available_action_exception")) {
+                        retry++;
+                    }
+                }
+            }
+            return GetResponse.of(b -> b.id(String.valueOf(id)).index(index).found(false));
+        }
+    }
+
+    private static class TestMailbox implements MailboxExecutor {
+
+        @Override
+        public void execute(
+                ThrowingRunnable<? extends Exception> command,
+                String descriptionFormat,
+                Object... descriptionArgs) {
+            try {
+                command.run();
+            } catch (Exception e) {
+                throw new RuntimeException("Unexpected error", e);
+            }
+        }
+
+        @Override
+        public void yield() throws InterruptedException, FlinkRuntimeException {
+            Thread.sleep(100);
+        }
+
+        @Override
+        public boolean tryYield() throws FlinkRuntimeException {
+            return false;
+        }
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/TestClientBase.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/TestClientBase.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.connector.elasticsearch.RequestTest;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch.core.GetResponse;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+abstract class TestClientBase {
+
+    private static final String DATA_FIELD_NAME = "data";
+    final ElasticsearchClient client;
+
+    TestClientBase(ElasticsearchClient client) {
+        this.client = client;
+    }
+
+    abstract GetResponse getResponse(String index, int id)
+            throws ElasticsearchException, IOException;
+
+    void assertThatIdsAreNotWritten(String index, int... ids)
+            throws ElasticsearchException, IOException {
+        for (final int id : ids) {
+            try {
+                final GetResponse response = getResponse(index, id);
+                assertThat(response.found())
+                        .as(String.format("Index %s Id %s is unexpectedly present.", index, id))
+                        .isFalse();
+            } catch (ElasticsearchException e) {
+                assertThat(e.status()).isEqualTo(404);
+            } catch (IOException ioe) {
+                throw ioe;
+            }
+        }
+    }
+
+    void assertThatIdsAreWritten(String index, int... ids)
+            throws IOException, InterruptedException {
+        for (final int id : ids) {
+            GetResponse response;
+            do {
+                response = getResponse(index, id);
+                Thread.sleep(1);
+            } while (!response.found());
+            assertThat(response.source()).isEqualTo(buildMessage(id));
+        }
+    }
+
+    String getDataFieldName() {
+        return DATA_FIELD_NAME;
+    }
+
+    static RequestTest.Product buildMessage(int id) {
+        return buildMessage(id, "test-" + id);
+    }
+
+    static RequestTest.Product buildMessage(int id, String name) {
+        return new RequestTest.Product(id, name);
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/TestEmitter8.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/TestEmitter8.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.sink;
+
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.elasticsearch.RequestTest;
+import org.apache.flink.connector.elasticsearch.bulk.RequestIndexer;
+
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
+
+class TestEmitter8 implements Elasticsearch8Emitter<Tuple2<Integer, RequestTest.Product>> {
+
+    private final String index;
+
+    public static TestEmitter8 jsonEmitter(String index, String dataFieldName) {
+        return new TestEmitter8(index);
+    }
+
+    private TestEmitter8(String index) {
+        this.index = index;
+    }
+
+    @Override
+    public void emit(
+            Tuple2<Integer, RequestTest.Product> element,
+            SinkWriter.Context context,
+            RequestIndexer indexer) {
+        indexer.add(createBulkOperation(element));
+    }
+
+    private BulkOperation createBulkOperation(Tuple2<Integer, RequestTest.Product> element) {
+        try {
+            return BulkOperation.of(
+                    b ->
+                            b.index(
+                                    IndexOperation.of(
+                                            f ->
+                                                    f.index(index)
+                                                            .id(element.f0.toString())
+                                                            .document(element.f1))));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-connector-elasticsearch8/src/test/resources/log4j2-test.properties
+++ b/flink-connector-elasticsearch8/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = DEBUG
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
I have been looking forward to this PR [[FLINK-26088][Connectors/ElasticSearch] Add Elasticsearch 8.0 support #53](https://github.com/apache/flink-connector-elasticsearch/pull/53) for a long time, but there has been no progress. We have no choice but to implement it ourselves. Maybe our implementation is not the most perfect. We look forward to your help.