### PR TITLE
[FLINK-34369][connectors/elasticsearch] Elasticsearch connector supports SSL context

### DIFF
--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSink.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSink.java
@@ -104,4 +104,9 @@ public class ElasticsearchSink<IN> implements Sink<IN> {
     BulkResponseInspectorFactory getBulkResponseInspectorFactory() {
         return bulkResponseInspectorFactory;
     }
+
+    @VisibleForTesting
+    NetworkClientConfig getNetworkClientConfig() {
+        return networkClientConfig;
+    }
 }

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
@@ -64,6 +64,7 @@ public abstract class ElasticsearchSinkBuilderBase<
     private Integer connectionTimeout;
     private Integer connectionRequestTimeout;
     private Integer socketTimeout;
+    private Boolean allowInsecure;
     private SerializableSupplier<SSLContext> sslContextSupplier;
     private SerializableSupplier<HostnameVerifier> hostnameVerifierSupplier;
     private FailureHandler failureHandler = new DefaultFailureHandler();
@@ -269,6 +270,19 @@ public abstract class ElasticsearchSinkBuilderBase<
         return self();
     }
 
+
+    /**
+     * Allows to bypass the certificates chain validation and connect to insecure network endpoints
+     * (for example, servers which use self-signed certificates).
+     *
+     * @param allowInsecure allow or not to insecure network endpoints
+     * @return this builder
+     */
+    public B setAllowInsecure(boolean allowInsecure) {
+        this.allowInsecure = allowInsecure;
+        return self();
+    }
+
     /**
      * Sets the supplier for getting an {@link SSLContext} instance.
      *
@@ -366,6 +380,7 @@ public abstract class ElasticsearchSinkBuilderBase<
                 connectionRequestTimeout,
                 connectionTimeout,
                 socketTimeout,
+                allowInsecure,
                 sslContextSupplier,
                 hostnameVerifierSupplier);
     }
@@ -409,6 +424,9 @@ public abstract class ElasticsearchSinkBuilderBase<
                 + '\''
                 + ", connectionPathPrefix='"
                 + connectionPathPrefix
+                + '\''
+                + ", allowInsecure='"
+                + allowInsecure
                 + '\''
                 + '}';
     }

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
@@ -35,6 +35,7 @@ import javax.net.ssl.SSLContext;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -372,7 +373,8 @@ public abstract class ElasticsearchSinkBuilderBase<
 
     private NetworkClientConfig buildNetworkClientConfig() {
         checkArgument(!hosts.isEmpty(), "Hosts cannot be empty.");
-
+        checkArgument(!Optional.ofNullable(allowInsecure).orElse(Boolean.FALSE) || sslContextSupplier == null,
+                "allowInsecure=true and sslContextSupplier are mutually exclusive.");
         return new NetworkClientConfig(
                 username,
                 password,

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
@@ -271,7 +271,6 @@ public abstract class ElasticsearchSinkBuilderBase<
         return self();
     }
 
-
     /**
      * Allows to bypass the certificates chain validation and connect to insecure network endpoints
      * (for example, servers which use self-signed certificates).
@@ -373,7 +372,9 @@ public abstract class ElasticsearchSinkBuilderBase<
 
     private NetworkClientConfig buildNetworkClientConfig() {
         checkArgument(!hosts.isEmpty(), "Hosts cannot be empty.");
-        checkArgument(!Optional.ofNullable(allowInsecure).orElse(Boolean.FALSE) || sslContextSupplier == null,
+        checkArgument(
+                !Optional.ofNullable(allowInsecure).orElse(Boolean.FALSE)
+                        || sslContextSupplier == null,
                 "allowInsecure=true and sslContextSupplier are mutually exclusive.");
         return new NetworkClientConfig(
                 username,

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
@@ -30,6 +30,7 @@ import org.apache.flink.util.function.SerializableSupplier;
 
 import org.apache.http.HttpHost;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
 import java.util.Arrays;
@@ -64,6 +65,7 @@ public abstract class ElasticsearchSinkBuilderBase<
     private Integer connectionRequestTimeout;
     private Integer socketTimeout;
     private SerializableSupplier<SSLContext> sslContextSupplier;
+    private SerializableSupplier<HostnameVerifier> hostnameVerifierSupplier;
     private FailureHandler failureHandler = new DefaultFailureHandler();
     private BulkResponseInspectorFactory bulkResponseInspectorFactory;
 
@@ -279,6 +281,18 @@ public abstract class ElasticsearchSinkBuilderBase<
     }
 
     /**
+     * Sets the supplier for getting an SSL {@link HostnameVerifier} instance.
+     *
+     * @param sslHostnameVerifierSupplier the serializable hostname verifier supplier function
+     * @return this builder
+     */
+    public B setSslHostnameVerifier(
+            SerializableSupplier<HostnameVerifier> sslHostnameVerifierSupplier) {
+        this.hostnameVerifierSupplier = sslHostnameVerifierSupplier;
+        return self();
+    }
+
+    /**
      * Overrides the default {@link FailureHandler}. A custom failure handler can handle partial
      * failures gracefully. See {@link #bulkResponseInspectorFactory} for more extensive control.
      *
@@ -352,7 +366,8 @@ public abstract class ElasticsearchSinkBuilderBase<
                 connectionRequestTimeout,
                 connectionTimeout,
                 socketTimeout,
-                sslContextSupplier);
+                sslContextSupplier,
+                hostnameVerifierSupplier);
     }
 
     private BulkProcessorConfig buildBulkProcessorConfig() {

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBase.java
@@ -26,8 +26,11 @@ import org.apache.flink.connector.elasticsearch.sink.BulkResponseInspector.BulkR
 import org.apache.flink.connector.elasticsearch.sink.ElasticsearchWriter.DefaultBulkResponseInspector;
 import org.apache.flink.connector.elasticsearch.sink.ElasticsearchWriter.DefaultFailureHandler;
 import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.function.SerializableSupplier;
 
 import org.apache.http.HttpHost;
+
+import javax.net.ssl.SSLContext;
 
 import java.util.Arrays;
 import java.util.List;
@@ -60,6 +63,7 @@ public abstract class ElasticsearchSinkBuilderBase<
     private Integer connectionTimeout;
     private Integer connectionRequestTimeout;
     private Integer socketTimeout;
+    private SerializableSupplier<SSLContext> sslContextSupplier;
     private FailureHandler failureHandler = new DefaultFailureHandler();
     private BulkResponseInspectorFactory bulkResponseInspectorFactory;
 
@@ -264,6 +268,17 @@ public abstract class ElasticsearchSinkBuilderBase<
     }
 
     /**
+     * Sets the supplier for getting an {@link SSLContext} instance.
+     *
+     * @param sslContextSupplier the serializable SSLContext supplier function
+     * @return this builder
+     */
+    public B setSslContextSupplier(SerializableSupplier<SSLContext> sslContextSupplier) {
+        this.sslContextSupplier = checkNotNull(sslContextSupplier);
+        return self();
+    }
+
+    /**
      * Overrides the default {@link FailureHandler}. A custom failure handler can handle partial
      * failures gracefully. See {@link #bulkResponseInspectorFactory} for more extensive control.
      *
@@ -336,7 +351,8 @@ public abstract class ElasticsearchSinkBuilderBase<
                 connectionPathPrefix,
                 connectionRequestTimeout,
                 connectionTimeout,
-                socketTimeout);
+                socketTimeout,
+                sslContextSupplier);
     }
 
     private BulkProcessorConfig buildBulkProcessorConfig() {

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriter.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriter.java
@@ -182,12 +182,14 @@ class ElasticsearchWriter<IN> implements SinkWriter<IN> {
                         if (networkClientConfig.isAllowInsecure().orElse(false)) {
                             try {
                                 httpClientBuilder.setSSLContext(
-                                        SSLContexts
-                                                .custom().loadTrustMaterial(TrustAllStrategy.INSTANCE).build());
+                                        SSLContexts.custom()
+                                                .loadTrustMaterial(TrustAllStrategy.INSTANCE)
+                                                .build());
                             } catch (final NoSuchAlgorithmException
-                                           | KeyStoreException
-                                           | KeyManagementException ex) {
-                                throw new IllegalStateException("Unable to create custom SSL context", ex);
+                                    | KeyStoreException
+                                    | KeyManagementException ex) {
+                                throw new IllegalStateException(
+                                        "Unable to create custom SSL context", ex);
                             }
                         } else if (networkClientConfig.getSSLContextSupplier() != null) {
                             // client creates SSL context using the configured supplier

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriter.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriter.java
@@ -30,9 +30,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
-import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.ssl.SSLContexts;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkProcessor;
@@ -49,9 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
 import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
@@ -169,7 +164,6 @@ class ElasticsearchWriter<IN> implements SinkWriter<IN> {
 
         final CredentialsProvider credentialsProvider = getCredentialsProvider(networkClientConfig);
         if (credentialsProvider != null
-                || networkClientConfig.isAllowInsecure().orElse(Boolean.FALSE)
                 || networkClientConfig.getSSLContextSupplier() != null
                 || networkClientConfig.getSslHostnameVerifier() != null) {
             builder.setHttpClientConfigCallback(
@@ -178,20 +172,7 @@ class ElasticsearchWriter<IN> implements SinkWriter<IN> {
                             httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
                         }
 
-                        // client uses trust-all model in case of self-signed certs
-                        if (networkClientConfig.isAllowInsecure().orElse(false)) {
-                            try {
-                                httpClientBuilder.setSSLContext(
-                                        SSLContexts.custom()
-                                                .loadTrustMaterial(TrustAllStrategy.INSTANCE)
-                                                .build());
-                            } catch (final NoSuchAlgorithmException
-                                    | KeyStoreException
-                                    | KeyManagementException ex) {
-                                throw new IllegalStateException(
-                                        "Unable to create custom SSL context", ex);
-                            }
-                        } else if (networkClientConfig.getSSLContextSupplier() != null) {
+                        if (networkClientConfig.getSSLContextSupplier() != null) {
                             // client creates SSL context using the configured supplier
                             httpClientBuilder.setSSLContext(
                                     networkClientConfig.getSSLContextSupplier().get());

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriter.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriter.java
@@ -163,7 +163,9 @@ class ElasticsearchWriter<IN> implements SinkWriter<IN> {
         }
 
         final CredentialsProvider credentialsProvider = getCredentialsProvider(networkClientConfig);
-        if (credentialsProvider != null || networkClientConfig.getSSLContextSupplier() != null) {
+        if (credentialsProvider != null
+                || networkClientConfig.getSSLContextSupplier() != null
+                || networkClientConfig.getSslHostnameVerifier() != null) {
             builder.setHttpClientConfigCallback(
                     httpClientBuilder -> {
                         if (credentialsProvider != null) {
@@ -172,6 +174,10 @@ class ElasticsearchWriter<IN> implements SinkWriter<IN> {
                         if (networkClientConfig.getSSLContextSupplier() != null) {
                             httpClientBuilder.setSSLContext(
                                     networkClientConfig.getSSLContextSupplier().get());
+                        }
+                        if (networkClientConfig.getSslHostnameVerifier() != null) {
+                            httpClientBuilder.setSSLHostnameVerifier(
+                                    networkClientConfig.getSslHostnameVerifier().get());
                         }
                         return httpClientBuilder;
                     });

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/NetworkClientConfig.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/NetworkClientConfig.java
@@ -25,7 +25,6 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
 import java.io.Serializable;
-import java.util.Optional;
 
 class NetworkClientConfig implements Serializable {
 
@@ -35,7 +34,6 @@ class NetworkClientConfig implements Serializable {
     @Nullable private final Integer connectionRequestTimeout;
     @Nullable private final Integer connectionTimeout;
     @Nullable private final Integer socketTimeout;
-    @Nullable private final Boolean allowInsecure;
     @Nullable private final SerializableSupplier<SSLContext> sslContextSupplier;
     @Nullable private final SerializableSupplier<HostnameVerifier> sslHostnameVerifier;
 
@@ -46,7 +44,6 @@ class NetworkClientConfig implements Serializable {
             @Nullable Integer connectionRequestTimeout,
             @Nullable Integer connectionTimeout,
             @Nullable Integer socketTimeout,
-            @Nullable Boolean allowInsecure,
             @Nullable SerializableSupplier<SSLContext> sslContextSupplier,
             @Nullable SerializableSupplier<HostnameVerifier> sslHostnameVerifier) {
         this.username = username;
@@ -55,7 +52,6 @@ class NetworkClientConfig implements Serializable {
         this.connectionRequestTimeout = connectionRequestTimeout;
         this.connectionTimeout = connectionTimeout;
         this.socketTimeout = socketTimeout;
-        this.allowInsecure = allowInsecure;
         this.sslContextSupplier = sslContextSupplier;
         this.sslHostnameVerifier = sslHostnameVerifier;
     }
@@ -88,10 +84,6 @@ class NetworkClientConfig implements Serializable {
     @Nullable
     public String getConnectionPathPrefix() {
         return connectionPathPrefix;
-    }
-
-    public Optional<Boolean> isAllowInsecure() {
-        return Optional.ofNullable(allowInsecure);
     }
 
     @Nullable

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/NetworkClientConfig.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/NetworkClientConfig.java
@@ -21,6 +21,7 @@ package org.apache.flink.connector.elasticsearch.sink;
 import org.apache.flink.util.function.SerializableSupplier;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
 import java.io.Serializable;
@@ -34,6 +35,7 @@ class NetworkClientConfig implements Serializable {
     @Nullable private final Integer connectionTimeout;
     @Nullable private final Integer socketTimeout;
     @Nullable private final SerializableSupplier<SSLContext> sslContextSupplier;
+    @Nullable private final SerializableSupplier<HostnameVerifier> sslHostnameVerifier;
 
     NetworkClientConfig(
             @Nullable String username,
@@ -42,7 +44,8 @@ class NetworkClientConfig implements Serializable {
             @Nullable Integer connectionRequestTimeout,
             @Nullable Integer connectionTimeout,
             @Nullable Integer socketTimeout,
-            @Nullable SerializableSupplier<SSLContext> sslContextSupplier) {
+            @Nullable SerializableSupplier<SSLContext> sslContextSupplier,
+            @Nullable SerializableSupplier<HostnameVerifier> sslHostnameVerifier) {
         this.username = username;
         this.password = password;
         this.connectionPathPrefix = connectionPathPrefix;
@@ -50,6 +53,7 @@ class NetworkClientConfig implements Serializable {
         this.connectionTimeout = connectionTimeout;
         this.socketTimeout = socketTimeout;
         this.sslContextSupplier = sslContextSupplier;
+        this.sslHostnameVerifier = sslHostnameVerifier;
     }
 
     @Nullable
@@ -85,5 +89,10 @@ class NetworkClientConfig implements Serializable {
     @Nullable
     public SerializableSupplier<SSLContext> getSSLContextSupplier() {
         return sslContextSupplier;
+    }
+
+    @Nullable
+    public SerializableSupplier<HostnameVerifier> getSslHostnameVerifier() {
+        return sslHostnameVerifier;
     }
 }

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/NetworkClientConfig.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/NetworkClientConfig.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.connector.elasticsearch.sink;
 
+import org.apache.flink.util.function.SerializableSupplier;
+
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
 
 import java.io.Serializable;
 
@@ -30,6 +33,7 @@ class NetworkClientConfig implements Serializable {
     @Nullable private final Integer connectionRequestTimeout;
     @Nullable private final Integer connectionTimeout;
     @Nullable private final Integer socketTimeout;
+    @Nullable private final SerializableSupplier<SSLContext> sslContextSupplier;
 
     NetworkClientConfig(
             @Nullable String username,
@@ -37,13 +41,15 @@ class NetworkClientConfig implements Serializable {
             @Nullable String connectionPathPrefix,
             @Nullable Integer connectionRequestTimeout,
             @Nullable Integer connectionTimeout,
-            @Nullable Integer socketTimeout) {
+            @Nullable Integer socketTimeout,
+            @Nullable SerializableSupplier<SSLContext> sslContextSupplier) {
         this.username = username;
         this.password = password;
         this.connectionPathPrefix = connectionPathPrefix;
         this.connectionRequestTimeout = connectionRequestTimeout;
         this.connectionTimeout = connectionTimeout;
         this.socketTimeout = socketTimeout;
+        this.sslContextSupplier = sslContextSupplier;
     }
 
     @Nullable
@@ -74,5 +80,10 @@ class NetworkClientConfig implements Serializable {
     @Nullable
     public String getConnectionPathPrefix() {
         return connectionPathPrefix;
+    }
+
+    @Nullable
+    public SerializableSupplier<SSLContext> getSSLContextSupplier() {
+        return sslContextSupplier;
     }
 }

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/NetworkClientConfig.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/sink/NetworkClientConfig.java
@@ -25,6 +25,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 class NetworkClientConfig implements Serializable {
 
@@ -34,6 +35,7 @@ class NetworkClientConfig implements Serializable {
     @Nullable private final Integer connectionRequestTimeout;
     @Nullable private final Integer connectionTimeout;
     @Nullable private final Integer socketTimeout;
+    @Nullable private final Boolean allowInsecure;
     @Nullable private final SerializableSupplier<SSLContext> sslContextSupplier;
     @Nullable private final SerializableSupplier<HostnameVerifier> sslHostnameVerifier;
 
@@ -44,6 +46,7 @@ class NetworkClientConfig implements Serializable {
             @Nullable Integer connectionRequestTimeout,
             @Nullable Integer connectionTimeout,
             @Nullable Integer socketTimeout,
+            @Nullable Boolean allowInsecure,
             @Nullable SerializableSupplier<SSLContext> sslContextSupplier,
             @Nullable SerializableSupplier<HostnameVerifier> sslHostnameVerifier) {
         this.username = username;
@@ -52,6 +55,7 @@ class NetworkClientConfig implements Serializable {
         this.connectionRequestTimeout = connectionRequestTimeout;
         this.connectionTimeout = connectionTimeout;
         this.socketTimeout = socketTimeout;
+        this.allowInsecure = allowInsecure;
         this.sslContextSupplier = sslContextSupplier;
         this.sslHostnameVerifier = sslHostnameVerifier;
     }
@@ -84,6 +88,10 @@ class NetworkClientConfig implements Serializable {
     @Nullable
     public String getConnectionPathPrefix() {
         return connectionPathPrefix;
+    }
+
+    public Optional<Boolean> isAllowInsecure() {
+        return Optional.ofNullable(allowInsecure);
     }
 
     @Nullable

--- a/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBaseTest.java
+++ b/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBaseTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.connector.elasticsearch.sink.BulkResponseInspector.BulkR
 import org.apache.flink.connector.elasticsearch.sink.ElasticsearchWriter.DefaultBulkResponseInspector;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.util.TestLoggerExtension;
+import org.apache.flink.util.function.SerializableSupplier;
 
 import org.apache.http.HttpHost;
 import org.junit.jupiter.api.DynamicTest;
@@ -30,6 +31,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.net.ssl.SSLContext;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
@@ -85,6 +88,17 @@ abstract class ElasticsearchSinkBuilderBaseTest<B extends ElasticsearchSinkBuild
                                         .setEmitter((element, indexer, context) -> {})
                                         .build())
                 .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testThrowIfBothAllowInsecureAndSslContextProviderSet() {
+        assertThatThrownBy(
+                () ->
+                        createMinimalBuilder()
+                                .setAllowInsecure(true)
+                                .setSslContextSupplier((SerializableSupplier<SSLContext>) () -> null)
+                                .build())
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBaseTest.java
+++ b/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchSinkBuilderBaseTest.java
@@ -93,11 +93,12 @@ abstract class ElasticsearchSinkBuilderBaseTest<B extends ElasticsearchSinkBuild
     @Test
     void testThrowIfBothAllowInsecureAndSslContextProviderSet() {
         assertThatThrownBy(
-                () ->
-                        createMinimalBuilder()
-                                .setAllowInsecure(true)
-                                .setSslContextSupplier((SerializableSupplier<SSLContext>) () -> null)
-                                .build())
+                        () ->
+                                createMinimalBuilder()
+                                        .setAllowInsecure(true)
+                                        .setSslContextSupplier(
+                                                (SerializableSupplier<SSLContext>) () -> null)
+                                        .build())
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriterITCase.java
+++ b/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriterITCase.java
@@ -327,7 +327,7 @@ class ElasticsearchWriterITCase {
                 bulkProcessorConfig,
                 new TestBulkProcessorBuilderFactory(),
                 new DefaultBulkResponseInspector(),
-                new NetworkClientConfig(null, null, null, null, null, null, false, null, null),
+                new NetworkClientConfig(null, null, null, null, null, null, null, null),
                 metricGroup,
                 new TestMailbox());
     }

--- a/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriterITCase.java
+++ b/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriterITCase.java
@@ -327,7 +327,7 @@ class ElasticsearchWriterITCase {
                 bulkProcessorConfig,
                 new TestBulkProcessorBuilderFactory(),
                 new DefaultBulkResponseInspector(),
-                new NetworkClientConfig(null, null, null, null, null, null, null, null),
+                new NetworkClientConfig(null, null, null, null, null, null, false, null, null),
                 metricGroup,
                 new TestMailbox());
     }

--- a/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriterITCase.java
+++ b/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriterITCase.java
@@ -327,7 +327,7 @@ class ElasticsearchWriterITCase {
                 bulkProcessorConfig,
                 new TestBulkProcessorBuilderFactory(),
                 new DefaultBulkResponseInspector(),
-                new NetworkClientConfig(null, null, null, null, null, null),
+                new NetworkClientConfig(null, null, null, null, null, null, null),
                 metricGroup,
                 new TestMailbox());
     }

--- a/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriterITCase.java
+++ b/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriterITCase.java
@@ -327,7 +327,7 @@ class ElasticsearchWriterITCase {
                 bulkProcessorConfig,
                 new TestBulkProcessorBuilderFactory(),
                 new DefaultBulkResponseInspector(),
-                new NetworkClientConfig(null, null, null, null, null, null, null),
+                new NetworkClientConfig(null, null, null, null, null, null, null, null),
                 metricGroup,
                 new TestMailbox());
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-34369

#### 02/05/2024
This is a preliminary PR that was tested locally with secure ES clusters. Plan is to get early feedback, add some tests, and test with deployed jobs.