### PR TITLE
[hotfix] Update dependencies

### DIFF
--- a/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -7,12 +7,12 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.carrotsearch:hppc:0.7.1
-- com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
-- com.fasterxml.jackson.core:jackson-annotations:2.13.4
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.4
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4
+- com.fasterxml.jackson.core:jackson-core:2.15.3
+- com.fasterxml.jackson.core:jackson-databind:2.15.3
+- com.fasterxml.jackson.core:jackson-annotations:2.15.3
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.15.3
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.15.3
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.3
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
 - org.apache.httpcomponents:httpasyncclient:4.1.2

--- a/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -7,12 +7,12 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.carrotsearch:hppc:0.8.1
-- com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
-- com.fasterxml.jackson.core:jackson-annotations:2.13.4
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.4
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4
+- com.fasterxml.jackson.core:jackson-core:2.15.3
+- com.fasterxml.jackson.core:jackson-databind:2.15.3
+- com.fasterxml.jackson.core:jackson-annotations:2.15.3
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.15.3
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.15.3
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.3
 - com.github.spullara.mustache.java:compiler:0.9.6
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3

--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,12 @@ under the License.
 	<properties>
 		<flink.version>1.17.1</flink.version>
 
-		<jackson-bom.version>2.13.4.20221013</jackson-bom.version>
+		<jackson-bom.version>2.15.3</jackson-bom.version>
 		<junit4.version>4.13.2</junit4.version>
-		<junit5.version>5.9.1</junit5.version>
-		<assertj.version>3.23.1</assertj.version>
-		<testcontainers.version>1.17.2</testcontainers.version>
-		<mockito.version>3.4.6</mockito.version>
+		<junit5.version>5.10.2</junit5.version>
+		<assertj.version>3.25.3</assertj.version>
+		<testcontainers.version>1.19.7</testcontainers.version>
+		<mockito.version>3.12.4</mockito.version>
 
 		<japicmp.skip>false</japicmp.skip>
 		<japicmp.referenceVersion>3.0.0-1.16</japicmp.referenceVersion>


### PR DESCRIPTION
jackson from 2.13.4.20221013 to 2.15.3
junit5 from 5.9.1 to 5.10.2
assertj from 3.23.1 to 3.25.3
testcontainers from 1.17.2 to 1.19.7
mockito from 3.4.6 to 3.12.4