### PR TITLE
[hotfix] Add support for Flink 1.20 and drop 1.16

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,12 +25,14 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 1.16-SNAPSHOT, 1.17-SNAPSHOT ]
+        flink: [ 1.17-SNAPSHOT ]
         jdk: [ '8, 11' ]
         include:
           - flink: 1.18-SNAPSHOT
             jdk: '8, 11, 17'
           - flink: 1.19-SNAPSHOT
+            jdk: '8, 11, 17, 21'
+          - flink: 1.20-SNAPSHOT
             jdk: '8, 11, 17, 21'
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -27,9 +27,6 @@ jobs:
     strategy:
       matrix:
         flink_branches: [{
-          flink: 1.16-SNAPSHOT,
-          branch: main
-        }, {
           flink: 1.17-SNAPSHOT,
           branch: main
         }, {
@@ -41,10 +38,17 @@ jobs:
           jdk: '8, 11, 17, 21',
           branch: main
         }, {
-          flink: 1.16.2,
+          flink: 1.20-SNAPSHOT,
+          jdk: '8, 11, 17, 21',
+          branch: main
+        }, {
+          flink: 1.17.2,
           branch: v3.0
         }, {
-          flink: 1.17.1,
+          flink: 1.18.1,
+          branch: v3.0
+        }, {
+          flink: 1.19.0,
           branch: v3.0
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils


### PR DESCRIPTION
The PR drops support for Flink 1.16 and adds 1.20 snapshot