### PR TITLE
[FLINK-35134][Connectors/Elasticsearch] Drop support for Flink 1.17

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,11 +28,9 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 1.17-SNAPSHOT ]
-        jdk: [ '8, 11' ]
+        flink: [ 1.18-SNAPSHOT ]
+        jdk: [ '8, 11, 17' ]
         include:
-          - flink: 1.18-SNAPSHOT
-            jdk: '8, 11, 17'
           - flink: 1.19-SNAPSHOT
             jdk: '8, 11, 17, 21'
           - flink: 1.20-SNAPSHOT

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,9 +30,6 @@ jobs:
     strategy:
       matrix:
         flink_branches: [{
-          flink: 1.17-SNAPSHOT,
-          branch: main
-        }, {
           flink: 1.18-SNAPSHOT,
           jdk: '8, 11, 17',
           branch: main
@@ -44,9 +41,6 @@ jobs:
           flink: 1.20-SNAPSHOT,
           jdk: '8, 11, 17, 21',
           branch: main
-        }, {
-          flink: 1.17.2,
-          branch: v3.0
         }, {
           flink: 1.18.1,
           branch: v3.0

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ under the License.
 	</modules>
 
 	<properties>
-		<flink.version>1.17.1</flink.version>
+		<flink.version>1.18.0</flink.version>
 
 		<jackson-bom.version>2.15.3</jackson-bom.version>
 		<junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION

Drop 1.17 runs from CI and bump default Flink version in pom
