### PR TITLE
[hotfix][Connector/Elasticsearch] Update version to 3.1-SNAPSHOT

### DIFF
--- a/flink-connector-elasticsearch-base/pom.xml
+++ b/flink-connector-elasticsearch-base/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-elasticsearch-parent</artifactId>
-		<version>4.0-SNAPSHOT</version>
+		<version>3.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch-base</artifactId>

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/pom.xml
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-elasticsearch-e2e-tests</artifactId>
-		<version>4.0-SNAPSHOT</version>
+		<version>3.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch-e2e-tests-common</artifactId>

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch6-e2e-tests/pom.xml
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch6-e2e-tests/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-elasticsearch-e2e-tests</artifactId>
-		<version>4.0-SNAPSHOT</version>
+		<version>3.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch6-e2e-tests</artifactId>

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch7-e2e-tests/pom.xml
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch7-e2e-tests/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-elasticsearch-e2e-tests</artifactId>
-		<version>4.0-SNAPSHOT</version>
+		<version>3.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch7-e2e-tests</artifactId>

--- a/flink-connector-elasticsearch-e2e-tests/pom.xml
+++ b/flink-connector-elasticsearch-e2e-tests/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-elasticsearch-parent</artifactId>
-		<version>4.0-SNAPSHOT</version>
+		<version>3.1-SNAPSHOT</version>
 	</parent>
 
 	<packaging>pom</packaging>

--- a/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connector-elasticsearch6/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-elasticsearch-parent</artifactId>
-		<version>4.0-SNAPSHOT</version>
+		<version>3.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch6</artifactId>

--- a/flink-connector-elasticsearch7/pom.xml
+++ b/flink-connector-elasticsearch7/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-elasticsearch-parent</artifactId>
-		<version>4.0-SNAPSHOT</version>
+		<version>3.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch7</artifactId>

--- a/flink-connector-elasticsearch8/pom.xml
+++ b/flink-connector-elasticsearch8/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-elasticsearch-parent</artifactId>
-		<version>4.0-SNAPSHOT</version>
+		<version>3.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch8</artifactId>

--- a/flink-sql-connector-elasticsearch6/pom.xml
+++ b/flink-sql-connector-elasticsearch6/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-elasticsearch-parent</artifactId>
-		<version>4.0-SNAPSHOT</version>
+		<version>3.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-connector-elasticsearch6</artifactId>

--- a/flink-sql-connector-elasticsearch7/pom.xml
+++ b/flink-sql-connector-elasticsearch7/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-elasticsearch-parent</artifactId>
-		<version>4.0-SNAPSHOT</version>
+		<version>3.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-connector-elasticsearch7</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ under the License.
 
 	<groupId>org.apache.flink</groupId>
 	<artifactId>flink-connector-elasticsearch-parent</artifactId>
-	<version>4.0-SNAPSHOT</version>
+	<version>3.1-SNAPSHOT</version>
 	<name>Flink : Connectors : Elasticsearch : Parent</name>
 	<packaging>pom</packaging>
 	<inceptionYear>2022</inceptionYear>


### PR DESCRIPTION
## Notes
- since there are no breaking changes from the latest release v3.0.1 the version should be v3.1 