### PR TITLE
[FLINK-36595][docs] Explicitly set connector compatibility as string …

### DIFF
--- a/docs/data/elastic.yml
+++ b/docs/data/elastic.yml
@@ -17,7 +17,7 @@
 ################################################################################
 
 version: 3.0.1
-flink_compatibility: [1.16, 1.17]
+flink_compatibility: ["1.16", "1.17"]
 variants:
   - maven: flink-connector-elasticsearch6
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch6/$full_version/flink-sql-connector-elasticsearch6-$full_version.jar


### PR DESCRIPTION
Explicitly set connector compatibility as string to prevent version comparison mismatch

### Purpose of the change

* Set version as string to prevent version comparison mismatch. Issue has happened for other connectors too: https://github.com/apache/flink-connector-kafka/pull/132

### Significant changes

No significant change