### PR TITLE
[FLINK-36987][docs] Correct the docs to the active ES table connector

### DIFF
--- a/docs/content.zh/docs/connectors/table/elasticsearch.md
+++ b/docs/content.zh/docs/connectors/table/elasticsearch.md
@@ -144,21 +144,8 @@ CREATE TABLE myUserTable (
       </td>
     </tr>
     <tr>
-      <td><h5>sink.delivery-guarantee</h5></td>
-      <td>optional</td>
-      <td style="word-wrap: break-word;">AT_LEAST_ONCE</td>
-      <td>String</td>
-      <td>Optional delivery guarantee when committing. Valid values are:
-      <ul>
-        <li><code>EXACTLY_ONCE</code>: records are only delivered exactly-once also under failover scenarios.</li>
-        <li><code>AT_LEAST_ONCE</code>: records are ensured to be delivered but it may happen that the same record is delivered multiple times.</li>
-        <li><code>NONE</code>:  records are delivered on a best effort basis.</li>
-      </ul>
-      </td>
-    </tr>
-    <tr>
       <td><h5>sink.flush-on-checkpoint</h5></td>
-      <td>optional</td>
+      <td>可选</td>
       <td style="word-wrap: break-word;">true</td>
       <td>Boolean</td>
       <td>在进行 checkpoint 时是否保证刷出缓冲区中的数据。如果关闭这一选项，在进行checkpoint时 sink 将不再为所有进行
@@ -225,28 +212,6 @@ CREATE TABLE myUserTable (
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>添加到每个 REST 通信中的前缀字符串，例如，<code>'/v1'</code>。</td>
-    </tr>
-    <tr>
-      <td><h5>connection.request-timeout</h5></td>
-      <td>可选</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>Duration</td>
-      <td>从连接管理器请求连接的超时时间。超时时间必须大于或者等于 0，如果设置为 0 则是无限超时。</td>
-    </tr>
-    <tr>
-      <td><h5>connection.timeout</h5></td>
-      <td>可选</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>Duration</td>
-      <td>建立请求的超时时间 。超时时间必须大于或者等于 0 ，如果设置为 0 则是无限超时。</td>
-    </tr>
-    <tr>
-      <td><h5>socket.timeout</h5></td>
-      <td>可选</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>Duration</td>
-      <td>等待数据的 socket 的超时时间 (SO_TIMEOUT)。超时时间必须大于或者等于 0，如果设置为 0 则是无限超时。
-      </td>
     </tr>
     <tr>
       <td><h5>format</h5></td>

--- a/docs/content/docs/connectors/table/elasticsearch.md
+++ b/docs/content/docs/connectors/table/elasticsearch.md
@@ -155,20 +155,6 @@ Connector Options
       </td>
     </tr>
     <tr>
-      <td><h5>sink.delivery-guarantee</h5></td>
-      <td>optional</td>
-      <td>no</td>
-      <td style="word-wrap: break-word;">AT_LEAST_ONCE</td>
-      <td>String</td>
-      <td>Optional delivery guarantee when committing. Valid values are:
-      <ul>
-        <li><code>EXACTLY_ONCE</code>: records are only delivered exactly-once also under failover scenarios.</li>
-        <li><code>AT_LEAST_ONCE</code>: records are ensured to be delivered but it may happen that the same record is delivered multiple times.</li>
-        <li><code>NONE</code>:  records are delivered on a best effort basis.</li>
-      </ul>
-      </td>
-    </tr>
-    <tr>
       <td><h5>sink.flush-on-checkpoint</h5></td>
       <td>optional</td>
       <td></td>
@@ -247,30 +233,6 @@ Connector Options
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>Prefix string to be added to every REST communication, e.g., <code>'/v1'</code>.</td>
-    </tr>
-    <tr>
-      <td><h5>connection.request-timeout</h5></td>
-      <td>optional</td>
-      <td>yes</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>Duration</td>
-      <td>The timeout for requesting a connection from the connection manager.</td>
-    </tr>
-    <tr>
-      <td><h5>connection.timeout</h5></td>
-      <td>optional</td>
-      <td>yes</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>Duration</td>
-      <td>The timeout for establishing a connection.</td>
-    </tr>
-    <tr>
-      <td><h5>socket.timeout</h5></td>
-      <td>optional</td>
-      <td>yes</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>Duration</td>
-      <td>The socket timeout (SO_TIMEOUT) for waiting for data or, put differently, a maximum period inactivity between two consecutive data packets.</td>
     </tr>
     <tr>
       <td><h5>format</h5></td>


### PR DESCRIPTION
After FLINK-30352, the current doc is mismatched to the active default ES table connector, this PR targets to correct this.