### PR TITLE
[hotfix] Supports specifying routing fields

### DIFF
--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchConfiguration.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchConfiguration.java
@@ -150,6 +150,10 @@ class ElasticsearchConfiguration {
         return config.getOptional(ElasticsearchConnectorOptions.CONNECTION_PATH_PREFIX);
     }
 
+    public String getPartitionRoutingFields() {
+        return config.get(ElasticsearchConnectorOptions.PARTITION_ROUTING_FIELDS);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchConnectorOptions.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchConnectorOptions.java
@@ -152,6 +152,12 @@ public class ElasticsearchConnectorOptions {
                             "The format must produce a valid JSON document. "
                                     + "Please refer to the documentation on formats for more details.");
 
+    public static final ConfigOption<String> PARTITION_ROUTING_FIELDS =
+            ConfigOptions.key("sink.partition-routing.fields")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Route field names list, multiple separated by commas.");
+
     // --------------------------------------------------------------------------------------------
     // Enums
     // --------------------------------------------------------------------------------------------

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/RequestFactory.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/RequestFactory.java
@@ -36,19 +36,17 @@ interface RequestFactory extends Serializable {
      * Creates an update request to be added to a {@link RequestIndexer}. Note: the type field has
      * been deprecated since Elasticsearch 7.x and it would not take any effort.
      */
-    UpdateRequest createUpdateRequest(
-            String index, String docType, String key, XContentType contentType, byte[] document);
+    UpdateRequest createUpdateRequest(String index, String docType, String key, String routing, XContentType contentType, byte[] document);
 
     /**
      * Creates an index request to be added to a {@link RequestIndexer}. Note: the type field has
      * been deprecated since Elasticsearch 7.x and it would not take any effort.
      */
-    IndexRequest createIndexRequest(
-            String index, String docType, String key, XContentType contentType, byte[] document);
+    IndexRequest createIndexRequest(String index, String docType, String key, String routing, XContentType contentType, byte[] document);
 
     /**
      * Creates a delete request to be added to a {@link RequestIndexer}. Note: the type field has
      * been deprecated since Elasticsearch 7.x and it would not take any effort.
      */
-    DeleteRequest createDeleteRequest(String index, String docType, String key);
+    DeleteRequest createDeleteRequest(String index, String docType, String key, String routing);
 }

--- a/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/KeyExtractorTest.java
+++ b/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/KeyExtractorTest.java
@@ -31,6 +31,8 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -128,5 +130,83 @@ public class KeyExtractorTest {
         assertThat(key)
                 .isEqualTo(
                         "1_2_3_4_true_1.0_2.0_ABCD_2012-12-12T12:12:12_2013-01-13T13:13:13_14:14:14_2015-05-15");
+    }
+
+    @Test
+    public void testStringColumnsExtractor() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .field("a", DataTypes.BIGINT().notNull())
+                        .field("b", DataTypes.STRING())
+                        .primaryKey("a")
+                        .build();
+
+        Function<RowData, String> keyExtractor = KeyExtractor.createColumnExtractor(schema, "_", "a,b");
+
+        String key = keyExtractor.apply(GenericRowData.of(12L, StringData.fromString("ABCD")));
+        assertThat(key).isEqualTo("12_ABCD");
+    }
+
+    @Test
+    public void testListColumnsExtractor() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .field("a", DataTypes.BIGINT().notNull())
+                        .field("b", DataTypes.STRING())
+                        .primaryKey("a")
+                        .build();
+
+        Function<RowData, String> keyExtractor = KeyExtractor.createColumnExtractor(schema, "_",
+                Arrays.asList("a", "b"));
+
+        String key = keyExtractor.apply(GenericRowData.of(12L, StringData.fromString("ABCD")));
+        assertThat(key).isEqualTo("12_ABCD");
+    }
+
+    @Test
+    public void testEmptyColumnsExtractor() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .field("a", DataTypes.BIGINT().notNull())
+                        .field("b", DataTypes.STRING())
+                        .primaryKey("a")
+                        .build();
+
+        String columns = null;
+        Function<RowData, String> keyExtractor = KeyExtractor.createColumnExtractor(schema, "_", columns);
+
+        String key = keyExtractor.apply(GenericRowData.of(12L, StringData.fromString("ABCD")));
+        assertThat(key).isEqualTo("");
+    }
+
+    @Test
+    public void testBlankColumnsExtractor() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .field("a", DataTypes.BIGINT().notNull())
+                        .field("b", DataTypes.STRING())
+                        .primaryKey("a")
+                        .build();
+
+        Function<RowData, String> keyExtractor = KeyExtractor.createColumnExtractor(schema, "_", "");
+
+        String key = keyExtractor.apply(GenericRowData.of(12L, StringData.fromString("ABCD")));
+        assertThat(key).isEqualTo("");
+    }
+
+    @Test
+    public void testNullColumnsExtractor() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .field("a", DataTypes.BIGINT().notNull())
+                        .field("b", DataTypes.STRING())
+                        .primaryKey("a")
+                        .build();
+
+        List<String> columns = null;
+        Function<RowData, String> keyExtractor = KeyExtractor.createColumnExtractor(schema, "_", columns);
+
+        String key = keyExtractor.apply(GenericRowData.of(12L, StringData.fromString("ABCD")));
+        assertThat(key).isEqualTo("");
     }
 }

--- a/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkFactory.java
+++ b/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkFactory.java
@@ -54,6 +54,7 @@ import static org.apache.flink.streaming.connectors.elasticsearch.table.Elastics
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.HOSTS_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.INDEX_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.KEY_DELIMITER_OPTION;
+import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.PARTITION_ROUTING_FIELDS;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.PASSWORD_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchConnectorOptions.USERNAME_OPTION;
 
@@ -76,7 +77,8 @@ public class Elasticsearch7DynamicSinkFactory implements DynamicTableSinkFactory
                             CONNECTION_PATH_PREFIX,
                             FORMAT_OPTION,
                             PASSWORD_OPTION,
-                            USERNAME_OPTION)
+                            USERNAME_OPTION,
+                            PARTITION_ROUTING_FIELDS)
                     .collect(Collectors.toSet());
 
     @Override


### PR DESCRIPTION
Supports specifying routing fields during write operations. Parameter name: sink.partition-routing.fields

e.g.
create temporary table order_info_sink (
  id BIGINT,
  user_id BIGINT,
  order_id BIGINT,
  PRIMARY KEY (id) NOT ENFORCED
) WITH(
  'connector' = 'elasticsearch-7',
  'hosts' = 'http://127.0.0.1:9200',
  'index' = 'order_info',
  'username' = 'elastic',
  'password' = 'mypassword',
  'sink.partition-routing.fields' = 'user_id'
);