### PR TITLE
Support multiple updates on a single document in ES8 client

### DIFF
--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncSinkBuilder.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncSinkBuilder.java
@@ -78,7 +78,7 @@ public class Elasticsearch8AsyncSinkBuilder<InputT>
      * The element converter that will be called on every stream element to be processed and
      * buffered.
      */
-    private ElementConverter<InputT, BulkOperationVariant> elementConverter;
+    private ElementConverter<InputT, List<BulkOperationVariant>> elementConverter;
 
     private SerializableSupplier<SSLContext> sslContextSupplier;
 
@@ -202,7 +202,7 @@ public class Elasticsearch8AsyncSinkBuilder<InputT>
      * @return {@code Elasticsearch8AsyncSinkBuilder}
      */
     public Elasticsearch8AsyncSinkBuilder<InputT> setElementConverter(
-            ElementConverter<InputT, BulkOperationVariant> elementConverter) {
+            ElementConverter<InputT, List<BulkOperationVariant>> elementConverter) {
         checkNotNull(elementConverter);
         this.elementConverter = elementConverter;
         return this;
@@ -232,7 +232,7 @@ public class Elasticsearch8AsyncSinkBuilder<InputT>
     }
 
     private OperationConverter<InputT> buildOperationConverter(
-            ElementConverter<InputT, BulkOperationVariant> converter) {
+            ElementConverter<InputT, List<BulkOperationVariant>> converter) {
         return converter != null ? new OperationConverter<>(converter) : null;
     }
 
@@ -244,9 +244,9 @@ public class Elasticsearch8AsyncSinkBuilder<InputT>
 
     /** A wrapper that evolves the Operation, since a BulkOperationVariant is not Serializable. */
     public static class OperationConverter<T> implements ElementConverter<T, Operation> {
-        private final ElementConverter<T, BulkOperationVariant> converter;
+        private final ElementConverter<T, List<BulkOperationVariant>> converter;
 
-        public OperationConverter(ElementConverter<T, BulkOperationVariant> converter) {
+        public OperationConverter(ElementConverter<T, List<BulkOperationVariant>> converter) {
             this.converter = converter;
         }
 

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncWriter.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncWriter.java
@@ -123,7 +123,12 @@ public class Elasticsearch8AsyncWriter<InputT> extends AsyncSinkWriter<InputT, O
 
         BulkRequest.Builder br = new BulkRequest.Builder();
         for (Operation operation : requestEntries) {
-            br.operations(new BulkOperation(operation.getBulkOperationVariant()));
+            operation
+                    .getBulkOperationVariant()
+                    .forEach(
+                            bulkOperationVariant -> {
+                                br.operations(new BulkOperation(bulkOperationVariant));
+                            });
         }
 
         esClient.bulk(br.build())

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Operation.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Operation.java
@@ -24,29 +24,30 @@ package org.apache.flink.connector.elasticsearch.sink;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperationVariant;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 
 /** A single stream element which contains a BulkOperationVariant. */
 public class Operation implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private final BulkOperationVariant bulkOperationVariant;
+    private final List<BulkOperationVariant> bulkOperationVariants;
 
-    public Operation(BulkOperationVariant bulkOperation) {
-        this.bulkOperationVariant = bulkOperation;
+    public Operation(List<BulkOperationVariant> bulkOperations) {
+        this.bulkOperationVariants = bulkOperations;
     }
 
-    public BulkOperationVariant getBulkOperationVariant() {
-        return bulkOperationVariant;
+    public List<BulkOperationVariant> getBulkOperationVariant() {
+        return bulkOperationVariants;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(bulkOperationVariant);
+        return Objects.hash(bulkOperationVariants);
     }
 
     @Override
     public String toString() {
-        return "Operation{" + "bulkOperationVariant=" + bulkOperationVariant + '}';
+        return "Operation{" + "bulkOperationVariant=" + bulkOperationVariants + '}';
     }
 }

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncSinkBuilderTest.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncSinkBuilderTest.java
@@ -25,6 +25,8 @@ import co.elastic.clients.elasticsearch.core.bulk.DeleteOperation;
 import org.apache.http.HttpHost;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 /** Tests for {@link Elasticsearch8AsyncSinkBuilder}. */
@@ -46,10 +48,11 @@ public class Elasticsearch8AsyncSinkBuilderTest {
                                 Elasticsearch8AsyncSinkBuilder.<String>builder()
                                         .setElementConverter(
                                                 (element, ctx) ->
-                                                        new DeleteOperation.Builder()
-                                                                .id("test")
-                                                                .index("test")
-                                                                .build())
+                                                        Arrays.asList(
+                                                                new DeleteOperation.Builder()
+                                                                        .id("test")
+                                                                        .index("test")
+                                                                        .build()))
                                         .build())
                 .isInstanceOf(NullPointerException.class);
     }
@@ -62,10 +65,11 @@ public class Elasticsearch8AsyncSinkBuilderTest {
                                         .setHosts(null)
                                         .setElementConverter(
                                                 (element, ctx) ->
-                                                        new DeleteOperation.Builder()
-                                                                .id("test")
-                                                                .index("test")
-                                                                .build())
+                                                        Arrays.asList(
+                                                                new DeleteOperation.Builder()
+                                                                        .id("test")
+                                                                        .index("test")
+                                                                        .build()))
                                         .build())
                 .isInstanceOf(NullPointerException.class);
     }

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncSinkITCase.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncSinkITCase.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -74,11 +75,12 @@ public class Elasticsearch8AsyncSinkITCase extends ElasticsearchSinkBaseITCase {
                                             ES_CONTAINER.getFirstMappedPort()))
                             .setElementConverter(
                                     (element, ctx) ->
-                                            new IndexOperation.Builder<>()
-                                                    .index(index)
-                                                    .id(element.getId())
-                                                    .document(element)
-                                                    .build())
+                                            Arrays.asList(
+                                                    new IndexOperation.Builder<>()
+                                                            .index(index)
+                                                            .id(element.getId())
+                                                            .document(element)
+                                                            .build()))
                             .build();
 
             env.fromElements("first", "second", "third", "fourth", "fifth")
@@ -110,11 +112,12 @@ public class Elasticsearch8AsyncSinkITCase extends ElasticsearchSinkBaseITCase {
                                             ES_CONTAINER.getFirstMappedPort()))
                             .setElementConverter(
                                     (element, ctx) ->
-                                            new IndexOperation.Builder<>()
-                                                    .index(index)
-                                                    .id(element.getId())
-                                                    .document(element)
-                                                    .build())
+                                            Arrays.asList(
+                                                    new IndexOperation.Builder<>()
+                                                            .index(index)
+                                                            .id(element.getId())
+                                                            .document(element)
+                                                            .build()))
                             .build();
 
             env.fromElements("first", "second", "third", "fourth", "fifth")

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncSinkSecureITCase.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncSinkSecureITCase.java
@@ -44,6 +44,8 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 
 import static org.apache.flink.connector.elasticsearch.sink.ElasticsearchSinkBaseITCase.DummyData;
 import static org.apache.flink.connector.elasticsearch.sink.ElasticsearchSinkBaseITCase.ELASTICSEARCH_IMAGE;
@@ -93,11 +95,12 @@ class Elasticsearch8AsyncSinkSecureITCase {
                                             "https"))
                             .setElementConverter(
                                     (element, ctx) ->
-                                            new IndexOperation.Builder<>()
-                                                    .index(index)
-                                                    .id(element.getId())
-                                                    .document(element)
-                                                    .build())
+                                            Collections.singletonList(
+                                                    new IndexOperation.Builder<>()
+                                                            .index(index)
+                                                            .id(element.getId())
+                                                            .document(element)
+                                                            .build()))
                             .setUsername(ES_CLUSTER_USERNAME)
                             .setPassword(ES_CLUSTER_PASSWORD)
                             .setSslContextSupplier(() -> ES_CONTAINER.createSslContextFromCa())

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncWriterITCase.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncWriterITCase.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Timeout;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -186,16 +187,18 @@ public class Elasticsearch8AsyncWriterITCase extends ElasticsearchSinkBaseITCase
         Elasticsearch8AsyncSinkBuilder.OperationConverter<DummyData> elementConverter =
                 new Elasticsearch8AsyncSinkBuilder.OperationConverter<>(
                         (element, ctx) ->
-                                new UpdateOperation.Builder<>()
-                                        .id(element.getId())
-                                        .index(index)
-                                        .action(
-                                                ac ->
-                                                        ac.doc(element)
-                                                                .docAsUpsert(
-                                                                        element.getId()
-                                                                                .equals("test-2")))
-                                        .build());
+                                Arrays.asList(
+                                        new UpdateOperation.Builder<>()
+                                                .id(element.getId())
+                                                .index(index)
+                                                .action(
+                                                        ac ->
+                                                                ac.doc(element)
+                                                                        .docAsUpsert(
+                                                                                element.getId()
+                                                                                        .equals(
+                                                                                                "test-2")))
+                                                .build()));
 
         try (final Elasticsearch8AsyncWriter<DummyData> writer =
                 createWriter(index, maxBatchSize, elementConverter)) {
@@ -214,11 +217,12 @@ public class Elasticsearch8AsyncWriterITCase extends ElasticsearchSinkBaseITCase
             getDefaultTestElementConverter(String index) {
         return new Elasticsearch8AsyncSinkBuilder.OperationConverter<>(
                 (element, ctx) ->
-                        new IndexOperation.Builder<DummyData>()
-                                .id(element.getId())
-                                .document(element)
-                                .index(index)
-                                .build());
+                        Collections.singletonList(
+                                new IndexOperation.Builder<DummyData>()
+                                        .id(element.getId())
+                                        .document(element)
+                                        .index(index)
+                                        .build()));
     }
 
     private Elasticsearch8AsyncWriter<DummyData> createWriter(String index, int maxBatchSize)

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/OperationSerializerTest.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/sink/OperationSerializerTest.java
@@ -35,6 +35,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,8 +44,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class OperationSerializerTest {
     @ParameterizedTest
     @MethodSource("operations")
-    public void testSerializeAndDeserialize(BulkOperationVariant operationVariant) {
-        Operation expectedState = new Operation(operationVariant);
+    public void testSerializeAndDeserialize(List<BulkOperationVariant> operationVariants) {
+        Operation expectedState = new Operation(operationVariants);
 
         final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         final DataOutputStream out = new DataOutputStream(bytes);


### PR DESCRIPTION
The ability to perform multiple updates on a single Elasticsearch document was available in the ES7 client but is currently not supported in the ES8 client.This PR introduces this feature in the ES8 client to align with ES7 functionality and support use cases requiring multiple update operations on the same document within a single lifecycle.