### PR TITLE
[FLINK-38371][Connectors / ElasticSearch] Add `sink.retry-on-conflicts` option to Elasticsearch Sink

### DIFF
--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchConfiguration.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchConfiguration.java
@@ -46,6 +46,7 @@ import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnec
 import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions.INDEX_OPTION;
 import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions.KEY_DELIMITER_OPTION;
 import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions.PASSWORD_OPTION;
+import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions.RETRY_ON_CONFLICTS;
 import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions.SOCKET_TIMEOUT;
 import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions.USERNAME_OPTION;
 import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
@@ -128,6 +129,10 @@ public class ElasticsearchConfiguration {
 
     public Optional<Integer> getParallelism() {
         return config.getOptional(SINK_PARALLELISM);
+    }
+
+    public int getRetryOnConflict() {
+        return config.get(RETRY_ON_CONFLICTS);
     }
 
     /**

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchConnectorOptions.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchConnectorOptions.java
@@ -145,4 +145,11 @@ public class ElasticsearchConnectorOptions {
                     .enumType(DeliveryGuarantee.class)
                     .defaultValue(DeliveryGuarantee.AT_LEAST_ONCE)
                     .withDescription("Optional delivery guarantee when committing.");
+
+    public static final ConfigOption<Integer> RETRY_ON_CONFLICTS =
+            ConfigOptions.key("sink.retry-on-conflicts")
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription(
+                            "The number of retry when conflicts with concurrent requests.");
 }

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSink.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSink.java
@@ -62,6 +62,7 @@ class ElasticsearchDynamicSink implements DynamicTableSink {
     final ElasticsearchSinkBuilderSupplier<RowData> builderSupplier;
     @Nullable final String documentType;
     final boolean isDynamicIndexWithSystemTime;
+    final int retryOnConflict;
 
     ElasticsearchDynamicSink(
             EncodingFormat<SerializationSchema<RowData>> format,
@@ -71,6 +72,7 @@ class ElasticsearchDynamicSink implements DynamicTableSink {
             String summaryString,
             ElasticsearchSinkBuilderSupplier<RowData> builderSupplier,
             @Nullable String documentType,
+            int retryOnConflict,
             ZoneId localTimeZoneId) {
         this.format = checkNotNull(format);
         this.physicalRowDataType = checkNotNull(physicalRowDataType);
@@ -79,6 +81,7 @@ class ElasticsearchDynamicSink implements DynamicTableSink {
         this.summaryString = checkNotNull(summaryString);
         this.builderSupplier = checkNotNull(builderSupplier);
         this.documentType = documentType;
+        this.retryOnConflict = retryOnConflict;
         this.localTimeZoneId = localTimeZoneId;
         this.isDynamicIndexWithSystemTime = isDynamicIndexWithSystemTime();
     }
@@ -127,6 +130,7 @@ class ElasticsearchDynamicSink implements DynamicTableSink {
                         format,
                         XContentType.JSON,
                         documentType,
+                        retryOnConflict,
                         createKeyExtractor());
 
         ElasticsearchSinkBuilderBase<RowData, ? extends ElasticsearchSinkBuilderBase> builder =
@@ -187,6 +191,7 @@ class ElasticsearchDynamicSink implements DynamicTableSink {
                 summaryString,
                 builderSupplier,
                 documentType,
+                retryOnConflict,
                 localTimeZoneId);
     }
 

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicTableFactoryBase.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicTableFactoryBase.java
@@ -128,6 +128,7 @@ abstract class ElasticsearchDynamicTableFactoryBase
                 capitalize(factoryIdentifier),
                 sinkBuilderSupplier,
                 getDocumentType(config),
+                config.getRetryOnConflict(),
                 getLocalTimeZoneId(context.getConfiguration()));
     }
 

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/RowElasticsearchEmitter.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/RowElasticsearchEmitter.java
@@ -50,17 +50,20 @@ class RowElasticsearchEmitter implements ElasticsearchEmitter<RowData> {
     private final XContentType contentType;
     @Nullable private final String documentType;
     private final Function<RowData, String> createKey;
+    private final int retryOnConflict;
 
     public RowElasticsearchEmitter(
             IndexGenerator indexGenerator,
             SerializationSchema<RowData> serializationSchema,
             XContentType contentType,
             @Nullable String documentType,
+            int retryOnConflict,
             Function<RowData, String> createKey) {
         this.indexGenerator = checkNotNull(indexGenerator);
         this.serializationSchema = checkNotNull(serializationSchema);
         this.contentType = checkNotNull(contentType);
         this.documentType = documentType;
+        this.retryOnConflict = retryOnConflict;
         this.createKey = checkNotNull(createKey);
     }
 
@@ -110,6 +113,9 @@ class RowElasticsearchEmitter implements ElasticsearchEmitter<RowData> {
                     new UpdateRequest(indexGenerator.generate(row), documentType, key)
                             .doc(document, contentType)
                             .upsert(document, contentType);
+            if (retryOnConflict != -1) {
+                updateRequest.retryOnConflict(retryOnConflict);
+            }
             indexer.add(updateRequest);
         } else {
             final IndexRequest indexRequest =


### PR DESCRIPTION
  This pull request introduces a new configuration option, sink.retry-on-conflicts, for the Elasticsearch table sink. This
  option allows users to specify the number of times to retry an update request when a version conflict occurs.


  In high-throughput streaming scenarios, it's possible for concurrent updates to the same document ID to cause version
  conflicts in Elasticsearch, leading to data loss. By setting this option, the sink can automatically retry the failed update,
  making the connector more resilient to such conflicts.

  Changes:
   * Added the sink.retry-on-conflicts option to ElasticsearchConnectorOptions. The default value is -1, which disables retries
     and maintains the previous behavior.
   * The option is propagated through the table factory and dynamic sink to the RowElasticsearchEmitter.
   * The UpdateRequest in RowElasticsearchEmitter is now configured with the specified number of retries on conflict.

  Example Usage:

  To enable retries, you can configure the option in your DDL:

    CREATE TABLE MyElasticsearchTable (
        -- columns
    ) WITH (
        'connector' = 'elasticsearch-7',
        'hosts' = 'http://localhost:9200',
        'index' = 'my-index',
        'sink.retry-on-conflicts' = '3' -- Retry up to 3 times on conflict
    );