### PR TITLE
[FLINK-38429] Reuse OperationSerializer in Elasticsearch 8 connector to improve perf

### DIFF
--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncWriter.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncWriter.java
@@ -69,6 +69,8 @@ public class Elasticsearch8AsyncWriter<InputT> extends AsyncSinkWriter<InputT, O
     /** A counter to track the number of bulk requests that are sent to Elasticsearch. */
     private final Counter numRequestSubmittedCounter;
 
+    private final OperationSerializer operationSerializer;
+
     private static final FatalExceptionClassifier ELASTICSEARCH_FATAL_EXCEPTION_CLASSIFIER =
             FatalExceptionClassifier.createChain(
                     new FatalExceptionClassifier(
@@ -112,6 +114,7 @@ public class Elasticsearch8AsyncWriter<InputT> extends AsyncSinkWriter<InputT, O
         this.numRecordsSendPartialFailureCounter =
                 metricGroup.counter("numRecordsSendPartialFailure");
         this.numRequestSubmittedCounter = metricGroup.counter("numRequestSubmitted");
+        this.operationSerializer = new OperationSerializer();
     }
 
     @Override
@@ -192,7 +195,7 @@ public class Elasticsearch8AsyncWriter<InputT> extends AsyncSinkWriter<InputT, O
 
     @Override
     protected long getSizeInBytes(Operation requestEntry) {
-        return new OperationSerializer().size(requestEntry);
+        return operationSerializer.size(requestEntry);
     }
 
     @Override


### PR DESCRIPTION
This PR proposes to improve perf for Elasticsearch 8 connector.
Currently, Elasticsearch 8 connector create a new `OperationSerializer` for each `Operation`.
A large amount of `OperationSerializer`'s instances brings big overhead.

There is a benchmark cases.

1. Flink application with single parallelism.
The Kafka Topic consumption rate show below.

|     Before this PR     |     After this PR      |
|--------------------|-------------------|
| 1.5 K strips/s(min)   | 2.3 K strips/s(min) |
| 2.0 K strips/s(max) | 2.9 K strips/s(max) |

<img width="752" height="452" alt="single" src="https://github.com/user-attachments/assets/2a69a1f4-8374-4e16-8a22-cc7764acc3a0" />

2. Flink application with 32 parallelisms.
The Kafka Topic consumption rate show below.

|     Before this PR     |     After this PR      |
|--------------------|-------------------|
| 58.3 K strips/s(min)  | 70.3 K strips/s(min) |
| 60.0 K strips/s(max) | 74.5 K strips/s(max) |

<img width="752" height="452" alt="32" src="https://github.com/user-attachments/assets/3f7cbc52-22de-4797-a416-008aba99363a" />

