### PR TITLE
[FLINK-20979][elasticsearch] Fix docs: use '-1' to disable bulk-flush options

### DIFF
--- a/docs/content.zh/docs/connectors/table/elasticsearch.md
+++ b/docs/content.zh/docs/connectors/table/elasticsearch.md
@@ -159,7 +159,7 @@ CREATE TABLE myUserTable (
       <td style="word-wrap: break-word;">1000</td>
       <td>Integer</td>
       <td>每个批量请求的最大缓冲操作数。
-      可以设置为<code>'0'</code>来禁用它（<code>elasticsearch-8</code>中必须大于0）。
+      可以设置为<code>'-1'</code>来禁用它（<code>elasticsearch-8</code>中必须大于0）。
       </td>
     </tr>
     <tr>
@@ -168,7 +168,7 @@ CREATE TABLE myUserTable (
       <td style="word-wrap: break-word;">2mb</td>
       <td>MemorySize</td>
       <td>每个批量请求的缓冲操作在内存中的最大值。单位必须为 MB。
-      可以设置为<code>'0'</code>来禁用它（<code>elasticsearch-8</code>中必须大于0）。
+      可以设置为<code>'-1'</code>来禁用它（<code>elasticsearch-8</code>中必须大于0）。
       </td>
     </tr>
     <tr>
@@ -177,7 +177,7 @@ CREATE TABLE myUserTable (
       <td style="word-wrap: break-word;">1s</td>
       <td>Duration</td>
       <td>flush 缓冲操作的间隔。
-        可以设置为<code>'0'</code>来禁用它（<code>elasticsearch-8</code>中必须大于0）。注意，<code>'sink.bulk-flush.max-size'</code>和<code>'sink.bulk-flush.max-actions'</code>都设置为<code>'0'</code>的这种 flush 间隔设置允许对缓冲操作进行完全异步处理（<code>elasticsearch-8</code>不支持如此配置，因其底层的异步 sink 要求所有 flush 参数必须为正数）。
+        可以设置为<code>'-1'</code>来禁用它（<code>elasticsearch-8</code>中必须大于0）。注意，<code>'sink.bulk-flush.max-size'</code>和<code>'sink.bulk-flush.max-actions'</code>都设置为<code>'0'</code>的这种 flush 间隔设置允许对缓冲操作进行完全异步处理（<code>elasticsearch-8</code>不支持如此配置，因其底层的异步 sink 要求所有 flush 参数必须为正数）。
       </td>
     </tr>
     <tr>

--- a/docs/content/docs/connectors/table/elasticsearch.md
+++ b/docs/content/docs/connectors/table/elasticsearch.md
@@ -173,7 +173,7 @@ Connector Options
       <td style="word-wrap: break-word;">1000</td>
       <td>Integer</td>
       <td>Maximum number of buffered actions per bulk request.
-      Can be set to <code>'0'</code> to disable it (must be greater than 0 in <code>elasticsearch 8</code>).
+      Can be set to <code>'-1'</code> to disable it (must be greater than 0 in <code>elasticsearch 8</code>).
       </td>
     </tr>
     <tr>
@@ -183,7 +183,7 @@ Connector Options
       <td style="word-wrap: break-word;">2mb</td>
       <td>MemorySize</td>
       <td>Maximum size in memory of buffered actions per bulk request. Must be in MB granularity.
-      Can be set to <code>'0'</code> to disable it (must be greater than 0 in <code>elasticsearch 8</code>).
+      Can be set to <code>'-1'</code> to disable it (must be greater than 0 in <code>elasticsearch 8</code>).
       </td>
     </tr>
     <tr>
@@ -193,7 +193,7 @@ Connector Options
       <td style="word-wrap: break-word;">1s</td>
       <td>Duration</td>
       <td>The interval to flush buffered actions.
-        Can be set to <code>'0'</code> to disable it (must be greater than 0 in <code>elasticsearch 8</code>). Note, both <code>'sink.bulk-flush.max-size'</code> and <code>'sink.bulk-flush.max-actions'</code>
+        Can be set to <code>'-1'</code> to disable it (must be greater than 0 in <code>elasticsearch 8</code>). Note, both <code>'sink.bulk-flush.max-size'</code> and <code>'sink.bulk-flush.max-actions'</code>
         can be set to <code>'0'</code> with the flush interval set allowing for complete async processing of buffered actions (not supported in <code>elasticsearch 8</code>, as its underlying async sink requires all flush parameters to be positive).
       </td>
     </tr>


### PR DESCRIPTION
## What is the purpose of the change

Fix incorrect documentation for `sink.bulk-flush.max-actions`, `sink.bulk-flush.max-size`, and `sink.bulk-flush.interval`. The docs state that `'0'` disables these options, but the code validates `maxActions == -1 || maxActions >= 1` — so `'0'` is invalid and `'-1'` is the correct disable value.

*JIRA: [FLINK-20979](https://issues.apache.org/jira/browse/FLINK-20979)*

## Brief change log

- Replace `'0'` with `'-1'` in the disable description for bulk-flush options (English and Chinese docs)

## Does this pull request potentially affect one of the following parts?

- Dependencies: **no**
- The public API: **no**
- The serializers: **no**
- The runtime per-record code paths: **no**
- Anything that affects deployment or recovery: **no**