### PR TITLE
[FLINK-28109][elasticsearch] Remove dead .id(key) call in RowElasticsearchEmitter

### DIFF
--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/RowElasticsearchEmitter.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/RowElasticsearchEmitter.java
@@ -120,7 +120,6 @@ class RowElasticsearchEmitter implements ElasticsearchEmitter<RowData> {
         } else {
             final IndexRequest indexRequest =
                     new IndexRequest(indexGenerator.generate(row), documentType)
-                            .id(key)
                             .source(document, contentType);
             indexer.add(indexRequest);
         }


### PR DESCRIPTION
## What is the purpose of the change

Remove dead code in `RowElasticsearchEmitter`. In the `else` branch, `key` is always `null` (the `if` checks `key != null`), so `.id(key)` is `.id(null)` — a no-op that confuses readers.

*JIRA: [FLINK-28109](https://issues.apache.org/jira/browse/FLINK-28109)*

## Brief change log

- Remove `.id(key)` from `IndexRequest` in the else branch of `processUpsert()` (1 line)

## Verifying this change

No behavioral change — `.id(null)` on an `IndexRequest` is a no-op (Elasticsearch auto-generates the ID). There is no direct unit test for `RowElasticsearchEmitter`; the code is covered indirectly by integration tests (`ElasticsearchDynamicSinkITCase`) which require a running Elasticsearch instance.

## Does this pull request potentially affect one of the following parts?

- Dependencies: **no**
- The public API: **no**
- The serializers: **no**
- The runtime per-record code paths: **no** (no behavioral change)
- Anything that affects deployment or recovery: **no**