### PR TITLE
[hotfix] Update ci run flink versions

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,7 +28,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 2.1-SNAPSHOT ]
+        flink: [ 2.2.1, 2.1.2 ]
         jdk: [ '11', '17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,17 +30,22 @@ jobs:
     strategy:
       matrix:
         flink_branches: [{
+          flink: 2.2-SNAPSHOT,
+          branch: main,
+          jdk: '11, 17, 21'
+        }, {
           flink: 2.1-SNAPSHOT,
           branch: main,
           jdk: '11, 17, 21'
         }, {
-          flink: 1.19.2,
-          branch: v3.0
+          flink: 2.0.2,
+          branch: 4.0,
+          jdk: '11, 17, 21'
         }, {
-          flink: 1.19.2,
+          flink: 1.19.3,
           branch: v3.1
         }, {
-          flink: 1.20.1,
+          flink: 1.20.4,
           branch: v3.1
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils


### PR DESCRIPTION
Update the flink version for `push_pr` and `weekly` ci.

This also fix the binary download issue raised by weekly ci: https://github.com/apache/flink-connector-elasticsearch/actions/runs/25722877029  