### PR TITLE
[hotfix] Correct branch name in ci

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -39,7 +39,7 @@ jobs:
           jdk: '11, 17, 21'
         }, {
           flink: 2.0.2,
-          branch: 4.0,
+          branch: v4.0,
           jdk: '11, 17, 21'
         }, {
           flink: 1.19.3,


### PR DESCRIPTION
The [weekly ci](https://github.com/apache/flink-connector-elasticsearch/actions/runs/25846087079/job/75941559348) failed since incorrect branch name in `.github/workflows/weekly.yml`.

<img width="1334" height="66" alt="image" src="https://github.com/user-attachments/assets/f9f57fcb-016d-4cb6-98f0-52336be46462" />
