### PR TITLE
[hotfix] Disable zk ha to fix weekly ci for v3.1 branch

### DIFF
--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/src/main/java/org/apache/flink/streaming/tests/ElasticsearchSinkE2ECaseBase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/src/main/java/org/apache/flink/streaming/tests/ElasticsearchSinkE2ECaseBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.tests;
 
 import org.apache.flink.connector.testframe.container.FlinkContainerTestEnvironment;
+import org.apache.flink.connector.testframe.container.FlinkContainersSettings;
 import org.apache.flink.connector.testframe.external.DefaultContainerizedExternalSystem;
 import org.apache.flink.connector.testframe.external.ExternalSystemDataReader;
 import org.apache.flink.connector.testframe.junit.annotations.TestEnv;
@@ -56,7 +57,12 @@ public abstract class ElasticsearchSinkE2ECaseBase<T extends Comparable<T>>
 
     // Defines TestEnvironment
     @TestEnv
-    protected FlinkContainerTestEnvironment flink = new FlinkContainerTestEnvironment(1, 6);
+    protected FlinkContainerTestEnvironment flink =
+            FlinkContainerTestEnvironment.fromSettings(
+                    FlinkContainersSettings.builder()
+                            .numTaskManagers(1)
+                            .numSlotsPerTaskManager(6)
+                            .build());
 
     // Defines ConnectorExternalSystem
     @TestExternalSystem


### PR DESCRIPTION
The FlinkContainerTestEnvironment enables Zookeeper HA, which fails the JobManager container in CI.

This following the fix in kafka and pulsar connector repo.