### PR TITLE
[FLINK-39706][ci] Remove flink 2.1 testing from es connector main branch

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -34,8 +34,8 @@ jobs:
           branch: main,
           jdk: '11, 17, 21'
         }, {
-          flink: 2.1-SNAPSHOT,
-          branch: main,
+          flink: 2.1.2,
+          branch: v4.0,
           jdk: '11, 17, 21'
         }, {
           flink: 2.0.2,


### PR DESCRIPTION
In order to support vector search, we need an es connector version that is compatible with Flink version >= 2.2. Meanwhile, I have synchronized all other important features on the main branch to the v4.0 branch (to support Flink >= 2.0 < 2.2)

Details: https://github.com/apache/flink-connector-elasticsearch/pull/137#issuecomment-4458785079