### PR TITLE
[FLINK-39716] Fix time unit for network timeout options

### DIFF
--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSink.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSink.java
@@ -167,15 +167,15 @@ class ElasticsearchDynamicSink implements DynamicTableSink {
 
         if (config.getConnectionRequestTimeout().isPresent()) {
             builder.setConnectionRequestTimeout(
-                    (int) config.getConnectionRequestTimeout().get().getSeconds());
+                    (int) config.getConnectionRequestTimeout().get().toMillis());
         }
 
         if (config.getConnectionTimeout().isPresent()) {
-            builder.setConnectionTimeout((int) config.getConnectionTimeout().get().getSeconds());
+            builder.setConnectionTimeout((int) config.getConnectionTimeout().get().toMillis());
         }
 
         if (config.getSocketTimeout().isPresent()) {
-            builder.setSocketTimeout((int) config.getSocketTimeout().get().getSeconds());
+            builder.setSocketTimeout((int) config.getSocketTimeout().get().toMillis());
         }
 
         return SinkV2Provider.of(builder.build(), config.getParallelism().orElse(null));

--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSource.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSource.java
@@ -121,15 +121,15 @@ public class ElasticsearchDynamicSource implements LookupTableSource, SupportsPr
 
         if (config.getConnectionRequestTimeout().isPresent()) {
             builder.setConnectionRequestTimeout(
-                    (int) config.getConnectionRequestTimeout().get().getSeconds());
+                    (int) config.getConnectionRequestTimeout().get().toMillis());
         }
 
         if (config.getConnectionTimeout().isPresent()) {
-            builder.setConnectionTimeout((int) config.getConnectionTimeout().get().getSeconds());
+            builder.setConnectionTimeout((int) config.getConnectionTimeout().get().toMillis());
         }
 
         if (config.getSocketTimeout().isPresent()) {
-            builder.setSocketTimeout((int) config.getSocketTimeout().get().getSeconds());
+            builder.setSocketTimeout((int) config.getSocketTimeout().get().toMillis());
         }
 
         return builder.build();


### PR DESCRIPTION
The unit of `socketTimeout`, `connectTimeout`, `connectionRequestTimeout` should be milliseconds.

See the java doc of `org.apache.http.client.config.RequestConfig#getSocketTimeout`.

<img width="673" height="249" alt="Clipboard_Screenshot_1779260687" src="https://github.com/user-attachments/assets/1bd81c6c-6f75-49d1-be9e-356a68843845" />
