### PR TITLE
[hotfix] Fix checkNotNull for Elasticsearch8AsyncSinkBuilder#setHeaders

### DIFF
--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncSinkBuilder.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncSinkBuilder.java
@@ -136,7 +136,7 @@ public class Elasticsearch8AsyncSinkBuilder<InputT>
      * @return {@code Elasticsearch8AsyncSinkBuilder}
      */
     public Elasticsearch8AsyncSinkBuilder<InputT> setHeaders(Header... headers) {
-        checkNotNull(hosts);
+        checkNotNull(headers);
         checkArgument(headers.length > 0, "Headers cannot be empty");
         this.headers = Arrays.asList(headers);
         return this;


### PR DESCRIPTION
This should be an unintentional mistake.