### PR TITLE
[FLINK-39798] Introduce uber jar for flink-connector-elasticsearch8 module

### DIFF
--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/utils/StringUtils.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/utils/StringUtils.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch.utils;
+
+/** Utils for string related operations. */
+public class StringUtils {
+    public static String capitalizeFirst(String str) {
+        if (str == null || str.isEmpty()) {
+            return str;
+        }
+        return str.substring(0, 1).toUpperCase() + str.substring(1);
+    }
+}

--- a/flink-connector-elasticsearch8/pom.xml
+++ b/flink-connector-elasticsearch8/pom.xml
@@ -191,13 +191,6 @@ under the License.
 		<dependencies>
 			<!-- For dependency convergence -->
 			<dependency>
-				<groupId>jakarta.json</groupId>
-				<artifactId>jakarta.json-api</artifactId>
-				<version>2.0.2</version>
-			</dependency>
-
-			<!-- For dependency convergence -->
-			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>
 				<version>${jackson.version}</version>

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch8DynamicTableFactory.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch8DynamicTableFactory.java
@@ -51,7 +51,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.apache.flink.connector.elasticsearch.table.Elasticsearch8ConnectorOptions.BULK_FLUSH_INTERVAL_OPTION;
 import static org.apache.flink.connector.elasticsearch.table.Elasticsearch8ConnectorOptions.BULK_FLUSH_MAX_ACTIONS_OPTION;
 import static org.apache.flink.connector.elasticsearch.table.Elasticsearch8ConnectorOptions.BULK_FLUSH_MAX_BUFFERED_ACTIONS_OPTION;
@@ -105,7 +104,7 @@ public class Elasticsearch8DynamicTableFactory extends AsyncDynamicTableSinkFact
         validateConfiguration(config);
 
         return new Elasticsearch8DynamicSource(
-                format, config, context.getPhysicalRowDataType(), capitalize(IDENTIFIER));
+                format, config, context.getPhysicalRowDataType(), capitalizeFirst(IDENTIFIER));
     }
 
     @Override
@@ -128,7 +127,7 @@ public class Elasticsearch8DynamicTableFactory extends AsyncDynamicTableSinkFact
                 .setPrimaryKeyLogicalTypesWithIndex(primaryKeyLogicalTypesWithIndex)
                 .setPhysicalRowDataType(context.getPhysicalRowDataType())
                 .setLocalTimeZoneId(getLocalTimeZoneId(context.getConfiguration()))
-                .setSummaryString(capitalize(IDENTIFIER))
+                .setSummaryString(capitalizeFirst(IDENTIFIER))
                 .build();
     }
 
@@ -264,5 +263,12 @@ public class Elasticsearch8DynamicTableFactory extends AsyncDynamicTableSinkFact
                         SOCKET_TIMEOUT,
                         SSL_CERTIFICATE_FINGERPRINT)
                 .collect(Collectors.toSet());
+    }
+
+    private static String capitalizeFirst(String str) {
+        if (str == null || str.isEmpty()) {
+            return str;
+        }
+        return str.substring(0, 1).toUpperCase() + str.substring(1);
     }
 }

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch8DynamicTableFactory.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch8DynamicTableFactory.java
@@ -70,6 +70,7 @@ import static org.apache.flink.connector.elasticsearch.table.Elasticsearch8Conne
 import static org.apache.flink.connector.elasticsearch.table.Elasticsearch8ConnectorOptions.SOCKET_TIMEOUT;
 import static org.apache.flink.connector.elasticsearch.table.Elasticsearch8ConnectorOptions.SSL_CERTIFICATE_FINGERPRINT;
 import static org.apache.flink.connector.elasticsearch.table.Elasticsearch8ConnectorOptions.USERNAME_OPTION;
+import static org.apache.flink.connector.elasticsearch.utils.StringUtils.capitalizeFirst;
 import static org.apache.flink.table.connector.source.lookup.LookupOptions.CACHE_TYPE;
 import static org.apache.flink.table.connector.source.lookup.LookupOptions.PARTIAL_CACHE_CACHE_MISSING_KEY;
 import static org.apache.flink.table.connector.source.lookup.LookupOptions.PARTIAL_CACHE_EXPIRE_AFTER_ACCESS;
@@ -263,12 +264,5 @@ public class Elasticsearch8DynamicTableFactory extends AsyncDynamicTableSinkFact
                         SOCKET_TIMEOUT,
                         SSL_CERTIFICATE_FINGERPRINT)
                 .collect(Collectors.toSet());
-    }
-
-    private static String capitalizeFirst(String str) {
-        if (str == null || str.isEmpty()) {
-            return str;
-        }
-        return str.substring(0, 1).toUpperCase() + str.substring(1);
     }
 }

--- a/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -8,8 +8,6 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.carrotsearch:hppc:0.8.1
 - com.fasterxml.jackson.core:jackson-core:2.15.3
-- com.fasterxml.jackson.core:jackson-databind:2.15.3
-- com.fasterxml.jackson.core:jackson-annotations:2.15.3
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.15.3
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.15.3
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.3

--- a/flink-sql-connector-elasticsearch8/pom.xml
+++ b/flink-sql-connector-elasticsearch8/pom.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connector-elasticsearch-parent</artifactId>
+		<version>4.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>flink-sql-connector-elasticsearch8</artifactId>
+	<name>Flink : Connectors : SQL : Elasticsearch 8</name>
+
+	<packaging>jar</packaging>
+
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-elasticsearch8</artifactId>
+			<version>${project.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.eclipse.parsson</groupId>
+					<artifactId>parsson</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${flink.version}</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>*:*</include>
+								</includes>
+							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>org.apache.httpcomponents:httpclient</artifact>
+									<excludes>
+										<exclude>mozilla/**</exclude>
+									</excludes>
+								</filter>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<!-- exclude Java 9+ multi-release entries; module-info.class breaks shading -->
+										<exclude>META-INF/versions/**</exclude>
+										<exclude>META-INF/services/com.fasterxml.**</exclude>
+										<!-- de-duplicate license/notice/manifest files contributed by bundled deps;
+											 the canonical NOTICE/LICENSE for this uber jar is shipped via
+											 src/main/resources/META-INF -->
+										<exclude>META-INF/LICENSE.txt</exclude>
+										<exclude>META-INF/LICENSE.md</exclude>
+										<exclude>META-INF/NOTICE.md</exclude>
+										<exclude>META-INF/DEPENDENCIES</exclude>
+										<exclude>META-INF/MANIFEST.MF</exclude>
+										<exclude>META-INF/FastDoubleParser-LICENSE</exclude>
+										<exclude>META-INF/FastDoubleParser-NOTICE</exclude>
+										<exclude>META-INF/bigint-LICENSE</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<relocations>
+								<!-- Relocate everything that is bundled into this uber jar -->
+								<relocation>
+									<pattern>co.elastic.clients</pattern>
+									<shadedPattern>org.apache.flink.elasticsearch8.shaded.co.elastic.clients</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.elasticsearch</pattern>
+									<shadedPattern>org.apache.flink.elasticsearch8.shaded.org.elasticsearch</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.http</pattern>
+									<shadedPattern>org.apache.flink.elasticsearch8.shaded.org.apache.http</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.commons</pattern>
+									<shadedPattern>org.apache.flink.elasticsearch8.shaded.org.apache.commons</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>org.apache.flink.elasticsearch8.shaded.com.fasterxml.jackson</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>jakarta.json</pattern>
+									<shadedPattern>org.apache.flink.elasticsearch8.shaded.jakarta.json</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.eclipse.yasson</pattern>
+									<shadedPattern>org.apache.flink.elasticsearch8.shaded.org.eclipse.yasson</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>io.opentelemetry</pattern>
+									<shadedPattern>org.apache.flink.elasticsearch8.shaded.io.opentelemetry</shadedPattern>
+								</relocation>
+							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-sql-connector-elasticsearch8/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-elasticsearch8/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,27 @@
+flink-sql-connector-elasticsearch8
+Copyright 2014-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- co.elastic.clients:elasticsearch-java:8.12.1
+- com.fasterxml.jackson.core:jackson-annotations:2.15.3
+- com.fasterxml.jackson.core:jackson-core:2.15.3
+- com.fasterxml.jackson.core:jackson-databind:2.15.3
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3
+- commons-codec:commons-codec:1.15
+- commons-logging:commons-logging:1.2
+- io.opentelemetry:opentelemetry-api:1.29.0
+- io.opentelemetry:opentelemetry-context:1.29.0
+- org.apache.httpcomponents:httpasyncclient:4.1.5
+- org.apache.httpcomponents:httpclient:4.5.13
+- org.apache.httpcomponents:httpcore:4.4.14
+- org.apache.httpcomponents:httpcore-nio:4.4.13
+- org.elasticsearch.client:elasticsearch-rest-client:8.12.1
+
+This project bundles the following dependencies under the Eclipse Public License 2.0 (https://www.eclipse.org/legal/epl-2.0/).
+See bundled license files for details.
+
+- jakarta.json:jakarta.json-api:2.0.2

--- a/flink-sql-connector-elasticsearch8/src/test/java/org/apache/flink/connectors/elasticsearch/PackagingITCase.java
+++ b/flink-sql-connector-elasticsearch8/src/test/java/org/apache/flink/connectors/elasticsearch/PackagingITCase.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.elasticsearch;
+
+import org.apache.flink.packaging.PackagingTestUtils;
+import org.apache.flink.table.factories.Factory;
+import org.apache.flink.test.resources.ResourceTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+
+class PackagingITCase {
+
+    @Test
+    void testPackaging() throws Exception {
+        final Path jar =
+                ResourceTestUtils.getResource(".*/flink-sql-connector-elasticsearch8-[^/]*\\.jar");
+
+        PackagingTestUtils.assertJarContainsOnlyFilesMatching(
+                jar,
+                Arrays.asList(
+                        "META-INF/",
+                        "org/apache/flink/connector/base/",
+                        "org/apache/flink/connector/elasticsearch/",
+                        "org/apache/flink/elasticsearch8/"));
+        PackagingTestUtils.assertJarContainsServiceEntry(jar, Factory.class);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,13 @@ under the License.
 				<version>1.1.10.4</version>
 			</dependency>
 
+			<!-- For dependency convergence  -->
+			<dependency>
+				<groupId>jakarta.json</groupId>
+				<artifactId>jakarta.json-api</artifactId>
+				<version>2.0.2</version>
+			</dependency>
+
 			<!-- For dependency convergence -->
 			<dependency>
 				<groupId>com.fasterxml.jackson</groupId>
@@ -388,6 +395,7 @@ under the License.
 			<modules>
 				<module>flink-sql-connector-elasticsearch6</module>
 				<module>flink-sql-connector-elasticsearch7</module>
+				<module>flink-sql-connector-elasticsearch8</module>
 			</modules>
 		</profile>
 	</profiles>


### PR DESCRIPTION
We need the uber jar to use es8 in sql environment.

Testing use the following sql in sql-client locally.

```sql
> CREATE TABLE es_sink (
>     id        BIGINT NOT NULL,
>     name      STRING,
>     amount    DOUBLE,
>     ts        TIMESTAMP(3),
>     PRIMARY KEY (id) NOT ENFORCED
> ) WITH (
>     'connector' = 'elasticsearch-8',
>     'hosts'     = 'http://localhost:9200',
>     'index'     = 'flink-test-sink'
> )

> INSERT INTO es_sink
> VALUES
>     (1, 'Alice',   100.50, TIMESTAMP '2026-01-01 10:00:00'),
>     (2, 'Bob',     200.75, TIMESTAMP '2026-01-02 11:00:00'),
>     (3, 'Charlie', 300.00, TIMESTAMP '2026-01-03 12:00:00')
```

