### PR TITLE
[FLINK-39816] Ship parsson into es8 uber jar

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,7 +28,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 2.3-SNAPSHOT ]
+        flink: [ 2.2-SNAPSHOT ]
         jdk: [ '11', '17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,7 +28,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 2.4-SNAPSHOT ]
+        flink: [ 2.3-SNAPSHOT ]
         jdk: [ '11', '17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,7 +28,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 2.2.1 ]
+        flink: [ 2.4-SNAPSHOT ]
         jdk: [ '11', '17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         flink_branches: [{
-          flink: 2.4-SNAPSHOT,
+          flink: 2.3-SNAPSHOT,
           branch: main,
           jdk: '11, 17, 21'
         }, {

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         flink_branches: [{
-          flink: 2.2-SNAPSHOT,
+          flink: 2.4-SNAPSHOT,
           branch: main,
           jdk: '11, 17, 21'
         }, {

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         flink_branches: [{
-          flink: 2.3-SNAPSHOT,
+          flink: 2.2-SNAPSHOT,
           branch: main,
           jdk: '11, 17, 21'
         }, {

--- a/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSinkBaseITCase.java
+++ b/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSinkBaseITCase.java
@@ -118,7 +118,7 @@ abstract class ElasticsearchDynamicSinkBaseITCase {
         GenericRowData rowData =
                 GenericRowData.of(
                         1L,
-                        12345,
+                        12000,
                         StringData.fromString("ABCDE"),
                         12.12f,
                         (byte) 2,
@@ -184,7 +184,7 @@ abstract class ElasticsearchDynamicSinkBaseITCase {
                 .fromValues(
                         row(
                                 1L,
-                                LocalTime.ofNanoOfDay(12345L * 1_000_000L),
+                                LocalTime.ofNanoOfDay(12000L * 1_000_000L),
                                 "ABCDE",
                                 12.12f,
                                 (byte) 2,
@@ -230,7 +230,7 @@ abstract class ElasticsearchDynamicSinkBaseITCase {
                 .fromValues(
                         row(
                                 1L,
-                                LocalTime.ofNanoOfDay(12345L * 1_000_000L),
+                                LocalTime.ofNanoOfDay(12000L * 1_000_000L),
                                 "ABCDE",
                                 12.12f,
                                 (byte) 2,
@@ -238,7 +238,7 @@ abstract class ElasticsearchDynamicSinkBaseITCase {
                                 LocalDateTime.parse("2012-12-12T12:12:12")),
                         row(
                                 2L,
-                                LocalTime.ofNanoOfDay(12345L * 1_000_000L),
+                                LocalTime.ofNanoOfDay(12000L * 1_000_000L),
                                 "FGHIJK",
                                 13.13f,
                                 (byte) 4,

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch8DynamicSinkITCase.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch8DynamicSinkITCase.java
@@ -85,7 +85,7 @@ class Elasticsearch8DynamicSinkITCase extends Elasticsearch8DynamicSinkBaseITCas
         GenericRowData rowData =
                 GenericRowData.of(
                         1L,
-                        12345,
+                        12000,
                         StringData.fromString("ABCDE"),
                         12.12f,
                         (byte) 2,
@@ -151,7 +151,7 @@ class Elasticsearch8DynamicSinkITCase extends Elasticsearch8DynamicSinkBaseITCas
                 .fromValues(
                         row(
                                 1L,
-                                LocalTime.ofNanoOfDay(12345L * 1_000_000L),
+                                LocalTime.ofNanoOfDay(12000L * 1_000_000L),
                                 "ABCDE",
                                 12.12f,
                                 (byte) 2,
@@ -196,7 +196,7 @@ class Elasticsearch8DynamicSinkITCase extends Elasticsearch8DynamicSinkBaseITCas
                 .fromValues(
                         row(
                                 1L,
-                                LocalTime.ofNanoOfDay(12345L * 1_000_000L),
+                                LocalTime.ofNanoOfDay(12000L * 1_000_000L),
                                 "ABCDE",
                                 12.12f,
                                 (byte) 2,
@@ -204,7 +204,7 @@ class Elasticsearch8DynamicSinkITCase extends Elasticsearch8DynamicSinkBaseITCas
                                 LocalDateTime.parse("2012-12-12T12:12:12")),
                         row(
                                 2L,
-                                LocalTime.ofNanoOfDay(12345L * 1_000_000L),
+                                LocalTime.ofNanoOfDay(12000L * 1_000_000L),
                                 "FGHIJK",
                                 13.13f,
                                 (byte) 4,

--- a/flink-sql-connector-elasticsearch8/pom.xml
+++ b/flink-sql-connector-elasticsearch8/pom.xml
@@ -43,12 +43,6 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-elasticsearch8</artifactId>
 			<version>${project.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.eclipse.parsson</groupId>
-					<artifactId>parsson</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -138,6 +132,10 @@ under the License.
 								<relocation>
 									<pattern>org.eclipse.yasson</pattern>
 									<shadedPattern>org.apache.flink.elasticsearch8.shaded.org.eclipse.yasson</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.eclipse.parsson</pattern>
+									<shadedPattern>org.apache.flink.elasticsearch8.shaded.org.eclipse.parsson</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>io.opentelemetry</pattern>

--- a/flink-sql-connector-elasticsearch8/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-elasticsearch8/src/main/resources/META-INF/NOTICE
@@ -25,3 +25,4 @@ This project bundles the following dependencies under the Eclipse Public License
 See bundled license files for details.
 
 - jakarta.json:jakarta.json-api:2.0.2
+- org.eclipse.parsson:parsson:1.0.5


### PR DESCRIPTION
We should ship `parsson` into uber jar, otherwise es client can not parse reponse(Elasticsearch-Java client relies on it for JSON parsing).