### PR TITLE
[FLINK-39809] Update flink-connector-parent to 2.0 for ElasticSearch connector

### DIFF
--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/utils/RestClientUtils.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/utils/RestClientUtils.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.elasticsearch.utils;
 
 import org.apache.flink.connector.elasticsearch.NetworkClientConfig;

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/src/main/java/org/apache/flink/streaming/tests/ElasticsearchSinkExternalContextBase.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/src/main/java/org/apache/flink/streaming/tests/ElasticsearchSinkExternalContextBase.java
@@ -47,6 +47,7 @@ abstract class ElasticsearchSinkExternalContextBase
     private static final int NUM_RECORDS_LOWER_BOUND = 100;
     protected static final int BULK_BUFFER = 100;
     protected static final int PAGE_LENGTH = NUM_RECORDS_UPPER_BOUND + 1;
+
     /** The index name. */
     protected final String indexName;
 

--- a/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/src/main/java/org/apache/flink/streaming/tests/KeyValue.java
+++ b/flink-connector-elasticsearch-e2e-tests/flink-connector-elasticsearch-e2e-tests-common/src/main/java/org/apache/flink/streaming/tests/KeyValue.java
@@ -31,6 +31,7 @@ public class KeyValue<K extends Comparable<? super K>, V extends Comparable<? su
 
     /** The key of the key-value pair. */
     public K key;
+
     /** The value the key-value pair. */
     public V value;
 

--- a/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncWriter.java
+++ b/flink-connector-elasticsearch8/src/main/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch8AsyncWriter.java
@@ -61,11 +61,13 @@ public class Elasticsearch8AsyncWriter<InputT> extends AsyncSinkWriter<InputT, O
     private boolean close = false;
 
     private final Counter numRecordsOutErrorsCounter;
+
     /**
      * A counter to track number of records that are returned by Elasticsearch as failed and then
      * retried by this writer.
      */
     private final Counter numRecordsSendPartialFailureCounter;
+
     /** A counter to track the number of bulk requests that are sent to Elasticsearch. */
     private final Counter numRequestSubmittedCounter;
 

--- a/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch8DynamicSinkBaseITCase.java
+++ b/flink-connector-elasticsearch8/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch8DynamicSinkBaseITCase.java
@@ -187,8 +187,12 @@ abstract class Elasticsearch8DynamicSinkBaseITCase {
     @SuppressWarnings({"unchecked"})
     List<Map<String, Object>> makeSearchRequest(String index)
             throws ExecutionException, InterruptedException {
-        return client.search(new SearchRequest.Builder().index(index).build(), Map.class).get()
-                .hits().hits().stream()
+        return client
+                .search(new SearchRequest.Builder().index(index).build(), Map.class)
+                .get()
+                .hits()
+                .hits()
+                .stream()
                 .map(hit -> (Map<String, Object>) hit.source())
                 .collect(Collectors.toList());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-parent</artifactId>
-		<version>1.0.0</version>
+		<version>2.0.0</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -31,11 +31,6 @@ This file is based on the checkstyle file of Apache Beam.
 
 <module name="Checker">
 
-	<module name="NewlineAtEndOfFile">
-		<!-- windows can use \r\n vs \n, so enforce the most used one ie UNIx style -->
-		<property name="lineSeparator" value="lf"/>
-	</module>
-
 	<module name="RegexpSingleline">
 		<!-- Checks that TODOs don't have stuff in parenthesis, e.g., username. -->
 		<property name="format" value="((//.*)|(\*.*))TODO\("/>
@@ -55,17 +50,9 @@ This file is based on the checkstyle file of Apache Beam.
 		<property name="severity" value="error"/>
 	</module>
 
-	<!-- Prevent *Tests.java as tools may not pick them up -->
-	<!--<module name="RegexpOnFilename">-->
-	<!--<property name="fileNamePattern" value=".*Tests\.java$" />-->
-	<!--</module>-->
-
 	<module name="SuppressionFilter">
 		<property name="file" value="${checkstyle.suppressions.file}" default="suppressions.xml"/>
 	</module>
-
-	<!-- Check that every module has a package-info.java -->
-	<!--<module name="JavadocPackage"/>-->
 
 	<!--
 
@@ -74,7 +61,7 @@ This file is based on the checkstyle file of Apache Beam.
 	-->
 
 	<module name="FileLength">
-		<property name="max" value="3000"/>
+		<property name="max" value="3100"/>
 	</module>
 
 	<!-- All Java AST specific tests live under TreeWalker module. -->
@@ -169,6 +156,11 @@ This file is based on the checkstyle file of Apache Beam.
 			<property name="illegalPattern" value="true"/>
 			<property name="message" value="Use com.fasterxml.jackson instead of jettison."/>
 		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.testcontainers\.shaded"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use utilities from appropriate library instead of org.testcontainers."/>
+		</module>
 
 		<!-- Enforce Java-style array declarations -->
 		<module name="ArrayTypeStyle"/>
@@ -184,30 +176,15 @@ This file is based on the checkstyle file of Apache Beam.
 
 		-->
 
-		<module name="RedundantImport">
-			<!-- Checks for redundant import statements. -->
-			<property name="severity" value="error"/>
-			<message key="import.redundancy"
-					 value="Redundant import {0}."/>
-		</module>
-
-		<module name="ImportOrder">
-			<!-- Checks for out of order import statements. -->
-			<property name="severity" value="error"/>
-			<property name="groups"
-					  value="org.apache.flink,*,javax,java,scala"/>
-			<property name="separated" value="true"/>
-			<property name="sortStaticImportsAlphabetically" value="true"/>
-			<property name="option" value="bottom"/>
-			<property name="tokens" value="STATIC_IMPORT, IMPORT"/>
-			<message key="import.ordering"
-					 value="Import {0} appears after other imports that it should precede"/>
-		</module>
-
 		<module name="AvoidStarImport">
 			<property name="severity" value="error"/>
 		</module>
 
+		<module name="IllegalImport">
+			<property name="illegalPkgs"
+					  value="org.mockito, org.powermock"/>
+			<message key="import.illegal" value="{0}; Mocking is discouraged. Please refer to the coding guidelines: https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#avoid-mockito---use-reusable-test-implementations."/>
+		</module>
 		<module name="IllegalImport">
 			<property name="illegalPkgs"
 					  value="autovalue.shaded, avro.shaded, com.google.api.client.repackaged, com.google.appengine.repackaged"/>
@@ -217,6 +194,10 @@ This file is based on the checkstyle file of Apache Beam.
 			<message key="import.illegal" value="{0}; Use flink-shaded-jackson instead."/>
 		</module>
 		<module name="IllegalImport">
+			<property name="illegalPkgs" value="com.jayway.jsonpath"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-jsonpath instead."/>
+		</module>
+		<module name="IllegalImport">
 			<property name="illegalPkgs" value="org.objectweb.asm"/>
 			<message key="import.illegal" value="{0}; Use flink-shaded-asm instead."/>
 		</module>
@@ -224,10 +205,14 @@ This file is based on the checkstyle file of Apache Beam.
 			<property name="illegalPkgs" value="io.netty"/>
 			<message key="import.illegal" value="{0}; Use flink-shaded-netty instead."/>
 		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="com.google.common"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-guava instead."/>
+		</module>
 
 		<module name="RedundantModifier">
 			<!-- Checks for redundant modifiers on various symbol definitions.
-			  See: http://checkstyle.sourceforge.net/config_modifier.html#RedundantModifier
+			  See: https://checkstyle.sourceforge.io/checks/modifier/redundantmodifier.html#RedundantModifier
 
 			  We exclude METHOD_DEF to allow final methods in final classes to make them more future-proof.
 			-->
@@ -239,9 +224,6 @@ This file is based on the checkstyle file of Apache Beam.
 			IllegalImport cannot blacklist classes, and c.g.api.client.util is used for some shaded
 			code and some useful code. So we need to fall back to Regexp.
 		-->
-		<!--<module name="RegexpSinglelineJava">-->
-		<!--<property name="format" value="com\.google\.api\.client\.util\.(ByteStreams|Charsets|Collections2|Joiner|Lists|Maps|Objects|Preconditions|Sets|Strings|Throwables)"/>-->
-		<!--</module>-->
 
 		<!--
 			 Require static importing from Preconditions.
@@ -251,11 +233,27 @@ This file is based on the checkstyle file of Apache Beam.
 			<property name="message" value="Static import functions from Guava Preconditions"/>
 		</module>
 
-		<module name="UnusedImports">
-			<property name="severity" value="error"/>
-			<property name="processJavadoc" value="true"/>
-			<message key="import.unused"
-					 value="Unused import: {0}."/>
+		<!--
+			The Nullable & Nonnull annotations check.
+		-->
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^import org.jetbrains.annotations.Nullable;$"/>
+			<property name="message" value="Use import javax.annotation.Nullable"/>
+		</module>
+
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^import org.jetbrains.annotations.NotNull;$"/>
+			<property name="message" value="Use import javax.annotation.Nonnull"/>
+		</module>
+
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^\s*@org.jetbrains.annotations.Nullable\s*$"/>
+			<property name="message" value="Use import javax.annotation.Nullable"/>
+		</module>
+
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^\s*@org.jetbrains.annotations.Nonnull\s*$"/>
+			<property name="message" value="Use import javax.annotation.Nonnull"/>
 		</module>
 
 		<!--
@@ -265,18 +263,12 @@ This file is based on the checkstyle file of Apache Beam.
 		-->
 
 		<!-- Checks for Javadoc comments.                     -->
-		<!-- See http://checkstyle.sf.net/config_javadoc.html -->
+		<!-- See https://checkstyle.sourceforge.io/checks/javadoc/javadocmethod.html -->
 		<module name="JavadocMethod">
-			<property name="scope" value="protected"/>
+			<property name="accessModifiers" value="protected"/>
 			<property name="severity" value="error"/>
-			<property name="allowMissingJavadoc" value="true"/>
 			<property name="allowMissingParamTags" value="true"/>
 			<property name="allowMissingReturnTag" value="true"/>
-			<property name="allowMissingThrowsTags" value="true"/>
-			<property name="allowThrowsTagsForSubclasses" value="true"/>
-			<property name="allowUndeclaredRTE" value="true"/>
-			<!-- This check sometimes failed for with "Unable to get class information for @throws tag" for custom exceptions -->
-			<property name="suppressLoadErrors" value="true"/>
 		</module>
 
 		<!-- Check that paragraph tags are used correctly in Javadoc. -->
@@ -380,44 +372,11 @@ This file is based on the checkstyle file of Apache Beam.
 			<property name="severity" value="error"/>
 		</module>
 
-		<!-- Type parameters must be either one of the four blessed letters
-		T, K, V, W, X or else be capital-case terminated with a T,
-		such as MyGenericParameterT -->
-		<!--<module name="ClassTypeParameterName">-->
-		<!--<property name="format" value="^(((T|K|V|W|X)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>-->
-		<!--<property name="severity" value="error"/>-->
-		<!--</module>-->
-
-		<!--<module name="MethodTypeParameterName">-->
-		<!--<property name="format" value="^(((T|K|V|W|X)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>-->
-		<!--<property name="severity" value="error"/>-->
-		<!--</module>-->
-
-		<!--<module name="InterfaceTypeParameterName">-->
-		<!--<property name="format" value="^(((T|K|V|W|X)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>-->
-		<!--<property name="severity" value="error"/>-->
-		<!--</module>-->
-
 		<!--
 
 		LENGTH and CODING CHECKS
 
 		-->
-
-		<!--<module name="LineLength">-->
-		<!--&lt;!&ndash; Checks if a line is too long. &ndash;&gt;-->
-		<!--<property name="max" value="100"/>-->
-		<!--<property name="severity" value="error"/>-->
-
-		<!--&lt;!&ndash;-->
-		<!--The default ignore pattern exempts the following elements:-->
-		<!-- - import statements-->
-		<!-- - long URLs inside comments-->
-		<!--&ndash;&gt;-->
-
-		<!--<property name="ignorePattern"-->
-		<!--value="^(package .*;\s*)|(import .*;\s*)|( *\* .*https?://.*)$"/>-->
-		<!--</module>-->
 
 		<!-- Checks for braces around if and else blocks -->
 		<module name="NeedBraces">
@@ -455,21 +414,6 @@ This file is based on the checkstyle file of Apache Beam.
 			<property name="ignoreComments" value="true"/>
 		</module>
 
-		<!--
-
-		MODIFIERS CHECKS
-
-		-->
-
-		<module name="ModifierOrder">
-			<!-- Warn if modifier order is inconsistent with JLS3 8.1.1, 8.3.1, and
-				 8.4.3.  The prescribed order is:
-				 public, protected, private, abstract, static, final, transient, volatile,
-				 synchronized, native, strictfp
-			  -->
-			<property name="severity" value="error"/>
-		</module>
-
 
 		<!--
 
@@ -488,71 +432,5 @@ This file is based on the checkstyle file of Apache Beam.
         INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF,
         CTOR_DEF"/>
 		</module>
-
-		<module name="WhitespaceAround">
-			<!-- Checks that various tokens are surrounded by whitespace.
-				 This includes most binary operators and keywords followed
-				 by regular or curly braces.
-			-->
-			<property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR,
-        BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN,
-        EQUAL, GE, GT, LAMBDA, LAND, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
-        LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
-        LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS,
-        MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION,
-        SL, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND"/>
-			<property name="severity" value="error"/>
-		</module>
-
-		<module name="WhitespaceAfter">
-			<!-- Checks that commas, semicolons and typecasts are followed by
-				 whitespace.
-			-->
-			<property name="tokens" value="COMMA, SEMI, TYPECAST"/>
-		</module>
-
-		<module name="NoWhitespaceAfter">
-			<!-- Checks that there is no whitespace after various unary operators.
-				 Linebreaks are allowed.
-			-->
-			<property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS,
-        UNARY_PLUS"/>
-			<property name="allowLineBreaks" value="true"/>
-			<property name="severity" value="error"/>
-		</module>
-
-		<module name="NoWhitespaceBefore">
-			<!-- Checks that there is no whitespace before various unary operators.
-				 Linebreaks are allowed.
-			-->
-			<property name="tokens" value="SEMI, DOT, POST_DEC, POST_INC"/>
-			<property name="allowLineBreaks" value="true"/>
-			<property name="severity" value="error"/>
-		</module>
-
-		<!--<module name="OperatorWrap">-->
-		<!--&lt;!&ndash; Checks that operators like + and ? appear at newlines rather than-->
-		<!--at the end of the previous line.-->
-		<!--&ndash;&gt;-->
-		<!--<property name="option" value="NL"/>-->
-		<!--<property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL,-->
-		<!--GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD,-->
-		<!--NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>-->
-		<!--</module>-->
-
-		<module name="OperatorWrap">
-			<!-- Checks that assignment operators are at the end of the line. -->
-			<property name="option" value="eol"/>
-			<property name="tokens" value="ASSIGN"/>
-		</module>
-
-		<module name="ParenPad">
-			<!-- Checks that there is no whitespace before close parens or after
-				 open parens.
-			-->
-			<property name="severity" value="error"/>
-		</module>
-
 	</module>
 </module>
-


### PR DESCRIPTION
Update `flink-connector-parent` to 2.0 and sync checkstyle with main repo.