### PR TITLE
[FLINK-40006] ElasticsearchRowDataLookupFunction leaks REST client / HTTP connections on task close

### DIFF
--- a/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/lookup/ElasticsearchRowDataLookupFunction.java
+++ b/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/lookup/ElasticsearchRowDataLookupFunction.java
@@ -191,4 +191,21 @@ public class ElasticsearchRowDataLookupFunction<C extends AutoCloseable> extends
 
         return row;
     }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            if (client != null) {
+                try {
+                    callBridge.close(client);
+                } catch (Exception e) {
+                    LOG.warn("Failed to close Elasticsearch client in lookup function.", e);
+                } finally {
+                    client = null;
+                }
+            }
+        } finally {
+            super.close();
+        }
+    }
 }


### PR DESCRIPTION
`ElasticsearchRowDataLookupFunction` creates the client in `open()` but never closes it.